### PR TITLE
%f is not available for git-log for git 1.5.5.6. %s and %f are almost same.

### DIFF
--- a/lib/Git/Repository.php
+++ b/lib/Git/Repository.php
@@ -224,7 +224,7 @@ class Repository
      */
     public function getCommits($file = null)
     {
-        $command = 'log --pretty=format:\'"%h": {"hash": "%H", "short_hash": "%h", "tree": "%T", "parent": "%P", "author": "%an", "author_email": "%ae", "date": "%at", "commiter": "%cn", "commiter_email": "%ce", "commiter_date": "%ct", "message": "%f"}\'';
+        $command = 'log --pretty=format:\'"%h": {"hash": "%H", "short_hash": "%h", "tree": "%T", "parent": "%P", "author": "%an", "author_email": "%ae", "date": "%at", "commiter": "%cn", "commiter_email": "%ce", "commiter_date": "%ct", "message": "%s"}\'';
         
         if ($file) {
             $command .= " $file";


### PR DESCRIPTION
Commit messages are not printed for git 1.5.5.6 (that's what I have on my VPS) because %f is not available for git-log format. %s is available and since we are not using the subject for naming a file, we can safely use %s.
