### PR TITLE
Support syntax highlighting for custom extensions

### DIFF
--- a/controllers/blobController.php
+++ b/controllers/blobController.php
@@ -6,6 +6,15 @@ $app->get('{repo}/blob/{branch}/{file}/', function($repo, $branch, $file) use($a
     $breadcrumbs = $app['utils']->getBreadcrumbs("$repo/tree/$branch/$file");
     $fileType = $app['utils']->getFileType($file);
 
+    if (isset($app['customfiletypes']) && is_array($app['customfiletypes'])) {
+      if (($pos = strrpos($file, '.')) !== FALSE) {
+        $fileExtension = substr($file, $pos + 1);
+        if (array_key_exists($fileExtension, $app['customfiletypes'])) {
+          $fileType = $app['customfiletypes'][$fileExtension];
+        }
+      }
+    }
+
     return $app['twig']->render('file.twig', array(
         'baseurl'        => $app['baseurl'],
         'page'           => 'files',

--- a/index.php
+++ b/index.php
@@ -15,6 +15,7 @@ require_once __DIR__.'/vendor/silex.phar';
 
 $app = new Silex\Application();
 $app['baseurl'] = $config['app']['baseurl'];
+$app['customfiletypes'] = $config['customfiletypes'];
 
 // Register Git and Twig libraries
 $app['autoloader']->registerNamespace('Git', __DIR__.'/lib');


### PR DESCRIPTION
This allows you to specify custom extension inside config.ini, custom entries override the default ones.

```
[customfiletypes]
module = php
install = php
```
