### PR TITLE
Read default branch from .git/HEAD

### DIFF
--- a/controllers/treeController.php
+++ b/controllers/treeController.php
@@ -2,7 +2,8 @@
 
 $app->get('{repo}/', function($repo) use($app) {
     $repository = $app['git']->getRepository($app['git.repos'] . $repo);
-    $tree = $repository->getTree('master');
+    $defaultBranch = $repository->getHead();
+    $tree = $repository->getTree($defaultBranch);
     $breadcrumbs = $app['utils']->getBreadcrumbs("$repo/");
 
     return $app['twig']->render('tree.twig', array(
@@ -10,7 +11,7 @@ $app->get('{repo}/', function($repo) use($app) {
         'page'           => 'files',
         'files'          => $tree->output(),
         'repo'           => $repo,
-        'branch'         => 'master',
+        'branch'         => $defaultBranch,
         'path'           => '',
         'parent'         => '',
         'breadcrumbs'    => $breadcrumbs,

--- a/lib/Git/Repository.php
+++ b/lib/Git/Repository.php
@@ -406,6 +406,25 @@ class Repository
         return $data;
     }
 
+    /**
+     * Get the current HEAD.
+     *
+     * @return string the name of the HEAD branch.
+     */
+    public function getHead()
+    {
+        $file = file_get_contents($this->getPath() . '/.git/HEAD');
+        foreach (explode("\n", $file) as $line) {
+            $m = array();
+            if (preg_match('#ref:\srefs/heads/(.+)#', $line, $m)) {
+                return $m[1];
+            }
+        }
+
+        // Default to something sane if in a detached HEAD state.
+        return 'master';
+    }
+
     public function getStatistics($branch)
     {
         // Calculate amount of files, extensions and file size

--- a/views/index.twig
+++ b/views/index.twig
@@ -9,7 +9,7 @@
     {% for repository in repositories %}
     <div class="repository">
         <div class="repository-header">
-            <i class="icon-folder-open icon-spaced"></i> <a href="{{ baseurl }}/{{ repository.name }}/tree/master/">{{ repository.name }}</a>
+            <i class="icon-folder-open icon-spaced"></i> <a href="{{ baseurl }}/{{ repository.name }}">{{ repository.name }}</a>
             <a href="{{ baseurl }}/{{ repository.name }}/master/rss/"><i class="rss pull-right"></i></a>
         </div>
         <div class="repository-body">


### PR DESCRIPTION
This is a fix for issue #61.

In this patch the default branch is read from .git/HEAD.  The index page link points to /[repo-name] which triggers the lookup on load.
