### PR TITLE
Interleave commits in blame

### DIFF
--- a/lib/Git/Repository.php
+++ b/lib/Git/Repository.php
@@ -477,24 +477,27 @@ class Repository
      */
     public function getBlame($file)
     {
+        $blame = array();
         $logs = $this->getClient()->run($this, "blame -s $file");
         $logs = explode("\n", $logs);
 
+        $i = 0;
+        $previous_commit = '';
         foreach ($logs as $log) {
             if ($log == '') {
                 continue;
             }
 
-            $split = preg_split("/[a-zA-Z0-9^]{8}[\s]+[0-9]+\)/", $log);
-            preg_match_all("/([a-zA-Z0-9^]{8})[\s]+([0-9]+)\)/", $log, $match);
+            preg_match_all("/([a-zA-Z0-9^]{8})[\s]+(.+)[\s]+([0-9]+)\)(.+)/", $log, $match);
 
-            $commit = $match[1][0];
-
-            if (!isset($blame[$commit]['line'])) {
-                $blame[$commit]['line'] = '';
+            $current_commit = $match[1][0];
+            if ($current_commit != $previous_commit) {
+                ++$i;
+                $blame[$i] = array('line' => '', 'commit' => $current_commit);
             }
 
-            $blame[$commit]['line'] .= PHP_EOL . $split[1];
+            $blame[$i]['line'] .= PHP_EOL . $match[4][0];
+            $previous_commit = $current_commit;
         }
 
         return $blame;

--- a/views/blame.twig
+++ b/views/blame.twig
@@ -21,9 +21,9 @@
             <div class="meta">{{ file }}</div>
         </div>
         <table class="blame-view">
-        {% for commit, blame in blames %}
+        {% for blame in blames %}
             <tr>
-                <td class="commit"><a href="{{ baseurl }}/{{ repo }}/commit/{{ commit }}/">{{ commit }}</a></td>
+                <td class="commit"><a href="{{ baseurl }}/{{ repo }}/commit/{{ blame.commit }}/">{{ blame.commit }}</a></td>
                 <td><pre>{{ blame.line }}</pre></td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
This is a fix for issue #57.

This patch interleaves commits in the blame output so it is rendered properly to the user.
