### PR TITLE
Enable app debug in config.ini

### DIFF
--- a/config.ini-example
+++ b/config.ini-example
@@ -6,6 +6,7 @@ repositories = '/var/www/projects/' ; Path to your repositories
 ; hidden[] = '/var/www/projects/BetaTest'
 
 [app]
+debug = false
 
 ; If you need to specify custom filetypes for certain extensions, do this here
 [filetypes]

--- a/index.php
+++ b/index.php
@@ -18,6 +18,7 @@ if (empty($config['git']['repositories']) || !is_dir($config['git']['repositorie
 require 'vendor/autoload.php';
 
 $app = new Silex\Application();
+$app['debug'] = isset($config['app']['debug']) && $config['app']['debug'];
 $app['filetypes'] = $config['filetypes'];
 $app['hidden'] = isset($config['git']['hidden']) ? $config['git']['hidden'] : array();
 $config['git']['repositories'] = rtrim($config['git']['repositories'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;


### PR DESCRIPTION
In development process, it is useful to enable debug in the silex application :
- Twig cache is automaticaly refreshed

This PR make it easy to configure.

```
[app]
debug = true
```
