### PR TITLE
nginx problem with zip/tar size

### DIFF
--- a/controllers/archiveController.php
+++ b/controllers/archiveController.php
@@ -28,7 +28,6 @@ $app->get('{repo}/{format}ball/{branch}', function($repo, $format, $branch) use 
         'Content-Description' => 'File Transfer',
         'Content-Disposition' => 'attachment; filename="'.$repo.'-'.substr($tree, 0, 6).'.'.$format.'"',
         'Content-Transfer-Encoding' => 'binary',
-        'Content-Length' => filesize($file),
     ));
 })->assert('format', '(zip|tar)')
   ->assert('repo', '[\w-._]+')


### PR DESCRIPTION
on nginx the download was very slow (+10sec) even if the file was already created, by removing the filesize from the headers, it downloaded fast (< 100ms)
