### PR TITLE
Move services init to a specific GitList\Application class

### DIFF
--- a/index.php
+++ b/index.php
@@ -12,41 +12,12 @@ $config = new GitList\Config('config.ini');
 $config->set('git', 'repositories', rtrim($config->get('git', 'repositories'), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
 
 // Startup and configure Silex application
-$app = new Silex\Application();
-$app['debug'] = $config->get('app', 'debug');
-$app['filetypes'] = $config->getSection('filetypes');
-$app['cache.archives'] = __DIR__ . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'archives';
-
-// Register services
-$app->register(new Silex\Provider\TwigServiceProvider(), array(
-    'twig.path'       => __DIR__ . '/views',
-    'twig.options'    => array('cache' => __DIR__ . '/cache'),
-));
-$app->register(new GitList\Provider\GitServiceProvider(), array(
-    'git.client'      => $config->get('git', 'client'),
-    'git.repos'       => $config->get('git', 'repositories'),
-    'git.hidden'      => $config->get('git', 'hidden') ? $config->get('git', 'hidden') : array(),
-));
-$app->register(new GitList\Provider\ViewUtilServiceProvider());
-$app->register(new GitList\Provider\RepositoryUtilServiceProvider());
-$app->register(new Silex\Provider\UrlGeneratorServiceProvider());
-
-$app['twig'] = $app->share($app->extend('twig', function($twig, $app) {
-    $twig->addFilter('md5', new Twig_Filter_Function('md5'));
-    return $twig;
-}));
+$app = new GitList\Application($config, __DIR__);
 
 // Mount the controllers
 $app->mount('', new GitList\Controller\MainController());
 $app->mount('', new GitList\Controller\BlobController());
 $app->mount('', new GitList\Controller\CommitController());
 $app->mount('', new GitList\Controller\TreeController());
-
-// Handle errors
-$app->error(function (\Exception $e, $code) use ($app) {
-    return $app['twig']->render('error.twig', array(
-        'message' => $e->getMessage(),
-    ));
-});
 
 $app->run();

--- a/lib/GitList/Application.php
+++ b/lib/GitList/Application.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace GitList;
+
+use Silex\Application as SilexApplication;
+use Silex\Provider\TwigServiceProvider;
+use Silex\Provider\UrlGeneratorServiceProvider;
+use GitList\Provider\GitServiceProvider;
+use GitList\Provider\RepositoryUtilServiceProvider;
+use GitList\Provider\ViewUtilServiceProvider;
+
+/**
+ * GitList application.
+ */
+class Application extends SilexApplication
+{
+    /**
+     * Constructor initialize services.
+     *
+     * @param Config $config
+     * @param string $root   Base path of the application files (views, cache)
+     */
+    public function __construct(Config $config, $root = null)
+    {
+        parent::__construct();
+
+        $app = $this;
+        $root = realpath($root);
+
+        $this['debug'] = $config->get('app', 'debug');
+        $this['filetypes'] = $config->getSection('filetypes');
+        $this['cache.archives'] = $root . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'archives';
+
+        // Register services
+        $this->register(new TwigServiceProvider(), array(
+            'twig.path'       => $root . DIRECTORY_SEPARATOR . 'views',
+            'twig.options'    => array('cache' => $root . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR . 'views'),
+        ));
+        $this->register(new GitServiceProvider(), array(
+            'git.client'      => $config->get('git', 'client'),
+            'git.repos'       => $config->get('git', 'repositories'),
+            'git.hidden'      => $config->get('git', 'hidden') ? $config->get('git', 'hidden') : array(),
+        ));
+        $this->register(new ViewUtilServiceProvider());
+        $this->register(new RepositoryUtilServiceProvider());
+        $this->register(new UrlGeneratorServiceProvider());
+
+        $this['twig'] = $this->share($this->extend('twig', function($twig, $app) {
+            $twig->addFilter('md5', new \Twig_Filter_Function('md5'));
+
+            return $twig;
+        }));
+
+        // Handle errors
+        $this->error(function (\Exception $e, $code) use ($app) {
+            return $app['twig']->render('error.twig', array(
+                'message' => $e->getMessage(),
+            ));
+        });
+    }
+}


### PR DESCRIPTION
Having a specific `GitList\Application` has many advantages :
- The app can be initialized very simply for functionnal tests or console application.
- Shortcut methods can be added (see http://silex.sensiolabs.org/doc/providers/twig.html#traits)
