### PR TITLE
Replace explicit getter calls in twig templates by property access

### DIFF
--- a/views/commit.twig
+++ b/views/commit.twig
@@ -5,38 +5,38 @@
 {% block title %}GitList{% endblock %}
 
 {% block content %}
-    {% include 'breadcrumb.twig' with {breadcrumbs: [{dir: "Commit #{commit.getHash}", path:''}]} %}
+    {% include 'breadcrumb.twig' with {breadcrumbs: [{dir: "Commit #{commit.hash}", path:''}]} %}
 
     <div class="commit-view">
         <div class="commit-header">
-            <span class="pull-right"><a class="btn btn-small" href="{{ path('branch', {repo: repo, branch: commit.getHash}) }}" title="Browse code at this point in history"><i class="icon-list-alt"></i> Browse code</a></span>
-            <h4>{{ commit.getMessage }}</h4>
+            <span class="pull-right"><a class="btn btn-small" href="{{ path('branch', {repo: repo, branch: commit.hash}) }}" title="Browse code at this point in history"><i class="icon-list-alt"></i> Browse code</a></span>
+            <h4>{{ commit.message }}</h4>
         </div>
         <div class="commit-body">
-            <img src="http://gravatar.com/avatar/{{ commit.getAuthor.getEmail | md5 }}?s=32" class="pull-left space-right" />
-            <span><a href="mailto:{{ commit.getAuthor.getEmail }}">{{ commit.getAuthor.getName }}</a> authored in {{ commit.getDate | date('d/m/Y \\a\\t H:i:s') }}<br />Showing {{ commit.getChangedFiles }} changed files</span>
+            <img src="http://gravatar.com/avatar/{{ commit.author.email | md5 }}?s=32" class="pull-left space-right" />
+            <span><a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored in {{ commit.date | date('d/m/Y \\a\\t H:i:s') }}<br />Showing {{ commit.changedFiles }} changed files</span>
         </div>
     </div>
 
     <ul class="commit-list">
-        {% for diff in commit.getDiffs %}
-            <li><i class="icon-file"></i> <a href="#{{ loop.index }}">{{ diff.getFile }}</a> <span class="meta pull-right">{{ diff.getIndex }}</span></li>
+        {% for diff in commit.diffs %}
+            <li><i class="icon-file"></i> <a href="#{{ loop.index }}">{{ diff.file }}</a> <span class="meta pull-right">{{ diff.index }}</span></li>
         {% endfor %}
     </ul>
 
-    {% for diff in commit.getDiffs %}
+    {% for diff in commit.diffs %}
     <div class="source-view">
         <div class="source-header">
-            <div class="meta"><a name="{{ loop.index }}">{{ diff.getFile }}</div>
+            <div class="meta"><a name="{{ loop.index }}">{{ diff.file }}</div>
 
             <div class="btn-group pull-right">
-                <a href="{{ path('blob', {repo: repo, branch: commit.getHash, file: diff.getFile}) }}" class="btn btn-small"><i class="icon-file"></i> View file @ {{ commit.getShortHash }}</a>
+                <a href="{{ path('blob', {repo: repo, branch: commit.hash, file: diff.file}) }}" class="btn btn-small"><i class="icon-file"></i> View file @ {{ commit.shortHash }}</a>
             </div>
         </div>
-        
+
         <div class="source-diff">
-        {% for line in diff.getLines %}
-            <pre{% if line.getType %} class="{{ line.getType }}"{% endif %}>{{ line.getLine }}</pre>
+        {% for line in diff.lines %}
+            <pre{% if line.type %} class="{{ line.type }}"{% endif %}>{{ line.line }}</pre>
         {% endfor %}
         </div>
     </div>

--- a/views/commits.twig
+++ b/views/commits.twig
@@ -17,11 +17,11 @@
         <tbody>
             {% for item in commit %}
             <tr>
-                <td width="5%"><img src="http://gravatar.com/avatar/{{ item.getAuthor.getEmail | md5 }}?s=40" /></td>
+                <td width="5%"><img src="http://gravatar.com/avatar/{{ item.author.email | md5 }}?s=40" /></td>
                 <td width="95%">
-                    <span class="pull-right"><a class="btn btn-small" href="{{ path('commit', {repo: repo, commit: item.getShortHash}) }}"><i class="icon-list-alt"></i> View {{ item.getShortHash }}</a></span>
-                    <h4>{{ item.getMessage }}</h4>
-                    <span><a href="mailto:{{ item.getAuthor.getEmail }}">{{ item.getAuthor.getName }}</a> authored in {{ item.getDate | date('d/m/Y \\a\\t H:i:s') }}</span>
+                    <span class="pull-right"><a class="btn btn-small" href="{{ path('commit', {repo: repo, commit: item.shortHash}) }}"><i class="icon-list-alt"></i> View {{ item.shortHash }}</a></span>
+                    <h4>{{ item.message }}</h4>
+                    <span><a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored in {{ item.date | date('d/m/Y \\a\\t H:i:s') }}</span>
                 </td>
             </tr>
             {% endfor %}

--- a/views/rss.twig
+++ b/views/rss.twig
@@ -7,10 +7,10 @@
 
         {% for commit in commits %}
         <item>
-            <title>{{ commit.getMessage }}</title>
-            <description>{{ commit.getAuthor.getName }} authored {{ commit.getShortHash }} in {{ commit.getDate | date('d/m/Y \\a\\t H:i:s') }}</description>
-            <link>{{ path('commit', {repo: repo, commit: commit.getShortHash}) }}</link>
-            <pubDate>{{ commit.getDate | date('r') }}</pubDate>
+            <title>{{ commit.message }}</title>
+            <description>{{ commit.author.name }} authored {{ commit.shortHash }} in {{ commit.date | date('d/m/Y \\a\\t H:i:s') }}</description>
+            <link>{{ path('commit', {repo: repo, commit: commit.shortHash}) }}</link>
+            <pubDate>{{ commit.date | date('r') }}</pubDate>
         </item>
         {% endfor %}
     </channel>


### PR DESCRIPTION
This simplify the twig syntax to access object properties via getter methods.
