### PR TITLE
Add history link to each file in diff view to make it easier to get to

### DIFF
--- a/views/commit.twig
+++ b/views/commit.twig
@@ -30,7 +30,7 @@
             <div class="meta"><a name="{{ loop.index }}">{{ diff.file }}</div>
 
             <div class="btn-group pull-right">
-                <a href="{{ path('commits', {repo: repo, branch: commit.getHash, file: diff.getFile}) }}" class="btn btn-small"><i class="icon-list-alt"></i> History</a>
+                <a href="{{ path('commits', {repo: repo, branch: commit.hash, file: diff.file}) }}" class="btn btn-small"><i class="icon-list-alt"></i> History</a>
                 <a href="{{ path('blob', {repo: repo, branch: commit.hash, file: diff.file}) }}" class="btn btn-small"><i class="icon-file"></i> View file @ {{ commit.shortHash }}</a>
             </div>
         </div>


### PR DESCRIPTION
that file's history. It's also possible to view the file at that revision
and then press the history button on the page that is loaded after clicking,
but this makes it faster and easier as well as more obvious.
