### PR TITLE
Adding composer.phar to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ nbproject
 node_modules
 config.ini
 cache.properties
+composer.phar


### PR DESCRIPTION
We don't want people accidentally committing this, so add it to the ignore list.
