### PR TITLE
Add check if readme is defined

### DIFF
--- a/views/tree.twig
+++ b/views/tree.twig
@@ -54,7 +54,7 @@
             {% endfor %}
         </tbody>
     </table>
-    {% if readme is not empty %}
+    {% if readme is defined and readme is not empty %}
         <div class="readme-view">
             <div class="readme-header">
                 <div class="meta">{{ readme.filename }}</div>


### PR DESCRIPTION
If I access subfolders in gitlist I get the following Error

Oops! Variable "readme" does not exist in "tree.twig" at line 53 

Add check if readme is defined fixes it.
