### PR TITLE
Added missing definition of WINDOWS_BUILD in boot.php (#155)

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -2,6 +2,8 @@
 
 if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
     define('WINDOWS_BUILD', 1);
+} else {
+    define('WINDOWS_BUILD', 0);
 }
 
 // Load configuration


### PR DESCRIPTION
Fixes missing WINDOWS_BUILD define
