### PR TITLE
Parse Markdown files

### DIFF
--- a/views/file.twig
+++ b/views/file.twig
@@ -19,6 +19,10 @@
         </div>
         {% if fileType == 'image' %}
         <center><img src="{{ path('blob_raw', {repo: repo, branch: branch, file: file}) }}" alt="{{ file }}" class="image-blob" /></center>
+
+        {% elseif fileType == 'markdown' %}
+        <div class="readme-view"><div id="readme-content">{{ blob }}</div></div>
+
         {% else %}
         <pre id="sourcecode" language="{{ fileType }}">{{ blob }}</pre>
         {% endif %}


### PR DESCRIPTION
Added the Markdown processor to the `file.twig` template file so that when you view a Markdown file, it is converted to HTML the same way that the `readme.md` files are.
