### PR TITLE
Fixes #141 Syntax hightlightning for Java not working

### DIFF
--- a/src/GitList/Util/Repository.php
+++ b/src/GitList/Util/Repository.php
@@ -16,7 +16,7 @@ class Repository
         'm'        => 'clike',
         'mm'       => 'clike',
         'cs'       => 'text/x-csharp',
-        'java'     => 'java',
+        'java'     => 'text/x-java',
         'clj'      => 'clojure',
         'coffee'   => 'coffeescript',
         'css'      => 'css',


### PR DESCRIPTION
Fixes #141 Syntax hightlightning for Java not working
