### PR TITLE
Fixed RewirteRule

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,7 +3,7 @@
 
     RewriteEngine On
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^ index.php [L]
+    RewriteRule ^(.*)$ /index.php [L,NC]
 </IfModule>
 <Files config.ini>
     order allow,deny


### PR DESCRIPTION
```
RewriteRule ^ index.php [L]
```

This is a very general rule that in some cases may generate errors like:

```
Request exceeded the limit of 10 internal redirects due to probable configuration error.
```
