### PR TITLE
fix situation when valid ref is a part of path

### DIFF
--- a/src/GitList/Util/Repository.php
+++ b/src/GitList/Util/Repository.php
@@ -199,7 +199,7 @@ class Repository
             // Otherwise, attempt to detect the ref using a list of the project's branches and tags
             $valid_refs = array_merge((array) $repository->getBranches(), (array) $repository->getTags());
             foreach ($valid_refs as $k => $v) {
-                if (!preg_match("#^{$v}/#", $input)) {
+                if (!preg_match(sprintf("#^%s/#", preg_quote($v, '#')), $input)) {
                     unset($valid_refs[$k]);
                 }
             }


### PR DESCRIPTION
it might happen that path already contains part, which is matching against valid ref name, but actually whole path does not refers to matched ref

for example, the valid refs
gantt
master

and path: master/assets/gantt/gantt.js

while iterating first ref will be matched, but the path actually is pointing to master ref

GitList\Util\Repository::extractRef() seems is overcomplicated,
but anyway, this is worked for me and tests confirmed that it's not breaks something
