### PR TITLE
improve get blame method retrieving long revisions to avoid ambiguity...

### DIFF
--- a/src/GitList/Controller/CommitController.php
+++ b/src/GitList/Controller/CommitController.php
@@ -72,7 +72,7 @@ class CommitController implements ControllerProviderInterface
           ->assert('branch', '[\w-._\/]+')
           ->bind('searchcommits');
 
-        $route->get('{repo}/commit/{commit}/', function($repo, $commit) use ($app) {
+        $route->get('{repo}/commit/{commit}', function($repo, $commit) use ($app) {
             $repository = $app['git']->getRepository($app['git.repos'] . $repo);
             $commit = $repository->getCommit($commit);
 

--- a/views/blame.twig
+++ b/views/blame.twig
@@ -14,7 +14,7 @@
         <table class="blame-view">
         {% for blame in blames %}
             <tr>
-                <td class="commit"><a href="{{ path('commit', {repo: repo, commit: blame.commit}) }}">{{ blame.commit }}</a></td>
+                <td class="commit"><a href="{{ path('commit', {repo: repo, commit: blame.commit}) }}">{{ blame.commitShort }}</a></td>
                 <td><pre>{{ blame.line }}</pre></td>
             </tr>
         {% endfor %}

--- a/views/commits_list.twig
+++ b/views/commits_list.twig
@@ -11,7 +11,7 @@
         <tr>
             <td width="5%"><img src="http://gravatar.com/avatar/{{ item.author.email | md5 }}?s=40" /></td>
             <td width="95%">
-                <span class="pull-right"><a class="btn btn-small" href="{{ path('commit', {repo: repo, commit: item.shortHash}) }}"><i class="icon-list-alt"></i> View {{ item.shortHash }}</a></span>
+                <span class="pull-right"><a class="btn btn-small" href="{{ path('commit', {repo: repo, commit: item.hash}) }}"><i class="icon-list-alt"></i> View {{ item.shortHash }}</a></span>
                 <h4>{{ item.message }}</h4>
                 <span><a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored in {{ item.date | date('d/m/Y \\a\\t H:i:s') }}</span>
             </td>

--- a/views/rss.twig
+++ b/views/rss.twig
@@ -9,7 +9,7 @@
         <item>
             <title>{{ commit.message }}</title>
             <description>{{ commit.author.name }} authored {{ commit.shortHash }} in {{ commit.date | date('d/m/Y \\a\\t H:i:s') }}</description>
-            <link>{{ path('commit', {repo: repo, commit: commit.shortHash}) }}</link>
+            <link>{{ path('commit', {repo: repo, commit: commit.hash}) }}</link>
             <pubDate>{{ commit.date | date('r') }}</pubDate>
         </item>
         {% endfor %}


### PR DESCRIPTION
...and omitting the caret of revisions (boundary commits)
