### PR TITLE
Fix minor grammar error in commit views

### DIFF
--- a/views/commit.twig
+++ b/views/commit.twig
@@ -14,7 +14,7 @@
         </div>
         <div class="commit-body">
             <img src="https://gravatar.com/avatar/{{ commit.author.email | md5 }}?s=32" class="pull-left space-right" />
-            <span><a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored in {{ commit.date | date('d/m/Y \\a\\t H:i:s') }}<br />Showing {{ commit.changedFiles }} changed files</span>
+            <span><a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | date('d/m/Y \\a\\t H:i:s') }}<br />Showing {{ commit.changedFiles }} changed files</span>
         </div>
     </div>
 

--- a/views/commits_list.twig
+++ b/views/commits_list.twig
@@ -13,7 +13,7 @@
             <td width="95%">
                 <span class="pull-right"><a class="btn btn-small" href="{{ path('commit', {repo: repo, commit: item.hash}) }}"><i class="icon-list-alt"></i> View {{ item.shortHash }}</a></span>
                 <h4>{{ item.message }}</h4>
-                <span><a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored in {{ item.date | date('d/m/Y \\a\\t H:i:s') }}</span>
+                <span><a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored on {{ item.date | date('d/m/Y \\a\\t H:i:s') }}</span>
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
Use the phrase "authored on <date>" rather than "authored in <date>".
