### PR TITLE
Use absolute URLs in RSS feeds 

### DIFF
--- a/views/rss.twig
+++ b/views/rss.twig
@@ -3,13 +3,13 @@
     <channel>
         <title>Latest commits in {{ repo }}:{{ branch }}</title>
         <description>RSS provided by GitList</description>
-        <link>{{ path('homepage') }}</link>
+        <link>{{ url('homepage') }}</link>
 
         {% for commit in commits %}
         <item>
             <title>{{ commit.message }}</title>
             <description>{{ commit.author.name }} authored {{ commit.shortHash }} in {{ commit.date | date('d/m/Y \\a\\t H:i:s') }}</description>
-            <link>{{ path('commit', {repo: repo, commit: commit.hash}) }}</link>
+            <link>{{ url('commit', {repo: repo, commit: commit.hash}) }}</link>
             <pubDate>{{ commit.date | date('r') }}</pubDate>
         </item>
         {% endfor %}


### PR DESCRIPTION
The current RSS template make use of relative URLs only. Many feed parsers will fail to adjust the commit links to the original GitList instance.
