### PR TITLE
Raw File View For PHP Strips Tags

### DIFF
--- a/src/GitList/Controller/BlobController.php
+++ b/src/GitList/Controller/BlobController.php
@@ -59,10 +59,9 @@ class BlobController implements ControllerProviderInterface
             $headers = array();
             if ($app['util.repository']->isBinary($file)) {
                 $headers['Content-Disposition'] = 'attachment; filename="' .  $file . '"';
-                $headers['Content-Transfer-Encoding'] = 'application/octet-stream';
-                $headers['Content-Transfer-Encoding'] = 'binary';
+                $headers['Content-Type'] = 'application/octet-stream';
             } else {
-                $headers['Content-Transfer-Encoding'] = 'text/plain';
+                $headers['Content-Type'] = 'text/plain';
             }
 
             return new Response($blob, 200, $headers);


### PR DESCRIPTION
When viewing PHP files as Raw, the opening `<?php` tags are being stripped, as well as a lot of the beginning code and all the formatting.  Other source files are also losing their formatting.

I do not believe `Content-Transfer-Encoding` is a valid HTTP header; rather, it is for email.  Switching the headers over to `Content-Type` resolves the issue.
