### PR TITLE
Missing parameters when generating blob_raw route

### DIFF
--- a/src/GitList/Controller/BlobController.php
+++ b/src/GitList/Controller/BlobController.php
@@ -27,8 +27,7 @@ class BlobController implements ControllerProviderInterface
             if ($fileType !== 'image' && $app['util.repository']->isBinary($file)) {
                 return $app->redirect($app['url_generator']->generate('blob_raw', array(
                     'repo'   => $repo,
-                    'branch' => $branch,
-                    'file'   => $file,
+                    'commitishPath' => $commitishPath,
                 )));
             }
 


### PR DESCRIPTION
When attempting to view a non-image binary file, the error `Some mandatory parameters are missing to generate a URL for route`.
