### PR TITLE
Show author statistics for the selected branch. Fixes #11

### DIFF
--- a/src/GitList/Controller/MainController.php
+++ b/src/GitList/Controller/MainController.php
@@ -38,7 +38,7 @@ class MainController implements ControllerProviderInterface
             }
 
             $stats = $repository->getStatistics($branch);
-            $authors = $repository->getAuthorStatistics();
+            $authors = $repository->getAuthorStatistics($branch);
 
             return $app['twig']->render('stats.twig', array(
                 'repo'           => $repo,

--- a/src/GitList/Git/Repository.php
+++ b/src/GitList/Git/Repository.php
@@ -292,9 +292,9 @@ class Repository extends BaseRepository
         return $searchResults;
     }
 
-    public function getAuthorStatistics()
+    public function getAuthorStatistics($branch)
     {
-        $logs = $this->getClient()->run($this, 'log --pretty=format:"%an||%ae" ' . $this->getHead());
+        $logs = $this->getClient()->run($this, 'log --pretty=format:"%an||%ae" ' . $branch);
 
         if (empty($logs)) {
             throw new \RuntimeException('No statistics available');


### PR DESCRIPTION
This makes `getAuthorStatistics` take a parameter called `$branch` much like the other functions, so the statistics returned are specific to that branch rather than always being based off the head.
