### PR TITLE
Make repositories list more compact

### DIFF
--- a/views/index.twig
+++ b/views/index.twig
@@ -6,19 +6,30 @@
 
 <div class="container">
 
-    {% for repository in repositories %}
-    <div class="repository">
-        <div class="repository-header">
-            <i class="icon-folder-open icon-spaced"></i> <a href="{{ path('repository', {repo: repository.name}) }}">{{ repository.name }}</a>
-            <a href="{{ path('rss', {repo: repository.name, branch: 'master'}) }}"><i class="rss pull-right"></i></a>
-        </div>
-        <div class="repository-body">
-            <p>{{ repository.description }}</p>
-        </div>
-    </div>
-    {% endfor %}
-
-    <hr />
+    {% if repositories|length == 0 %}
+        No repositories found.
+    {% else %}
+        <table class="table table-bordered table-striped table-condensed">
+        <tbody>
+            {% for repository in repositories %}
+            <tr>
+                <td>
+                    <i class="icon-folder-open icon-spaced"></i>
+                    <a href="{{ path('repository', {repo: repository.name}) }}">
+                        {{ repository.name }}
+                    </a>
+                </td>
+                <td>
+                    {{ repository.description }}
+                </td>
+                <td style="width: 1%;">
+                    <a href="{{ path('rss', {repo: repository.name, branch: 'master'}) }}"><i class="rss pull-right"></i></a>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+        </table>
+    {% endif %}
 
     {% include 'footer.twig' %}
 </div>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -272,8 +272,6 @@ table .span24{float:none;width:1884px;margin-left:0;}
 .commit-view .commit-body{padding:8px;}
 .commit-list{list-style-type:none;}.commit-list li{padding:8px 5px 8px 5px;font-size:14px;font-weight:700;border-bottom:1px solid #d7d7d7;}.commit-list li .meta{font-weight:normal;font-size:14px;color:#999999;}
 .commit-list li:last-child{border-bottom:0;margin-bottom:25px;}
-.repository{margin-bottom:18px;border:1px solid #d7d7d7;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;}.repository .repository-header{border-bottom:1px solid #d7d7d7;text-shadow:1px 1px 1px #ffffff;padding:8px;font-weight:700;font-size:14px;}
-.repository .repository-body{padding:8px;background-color:#f7f7f7;}.repository .repository-body p{margin:0;}
 .readme-view{border:1px solid #cacaca;}
 .md-view{width:100%;margin-bottom:18px;}
 .md-header{padding:8px;line-height:18px;text-align:left;vertical-align:bottom;background-color:#f4f4f4;background-image:-moz-linear-gradient(top, #fafafa, #eaeaea);background-image:-ms-linear-gradient(top, #fafafa, #eaeaea);background-image:-webkit-gradient(linear, 0 0, 0 100%, from(#fafafa), to(#eaeaea));background-image:-webkit-linear-gradient(top, #fafafa, #eaeaea);background-image:-o-linear-gradient(top, #fafafa, #eaeaea);background-image:linear-gradient(top, #fafafa, #eaeaea);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fafafa', endColorstr='#eaeaea', GradientType=0);border-bottom:1px solid #d7d7d7;font-weight:bold;color:#555555;text-shadow:1px 1px 1px #ffffff;height:28px;}.md-header .meta{float:left;padding:4px 0;font-size:14px;}

--- a/web/less/files.less
+++ b/web/less/files.less
@@ -138,28 +138,6 @@
   li:last-child {border-bottom:0;margin-bottom:25px;}
 }
 
-.repository {
-  margin-bottom: @baseLineHeight;
-  border: 1px solid lighten(@treeHeaderBorder, 5%);
-  .border-radius(4px);
-
-  .repository-header {
-    border-bottom: 1px solid lighten(@treeHeaderBorder, 5%);
-    text-shadow: 1px 1px 1px rgba(255,255,255,1);
-    padding: 8px;
-    font-weight: 700;
-    font-size:14px;
-  }
-
-  .repository-body {
-    padding: 8px;
-    background-color: lighten(@treeHeader, 5%);
-    p {
-      margin: 0;
-    }
-  }
-}
-
 .readme-view {
   border: 1px solid @treeHeaderBorder;
 }


### PR DESCRIPTION
The old layout is quite wasteful when it comes to screen space,
especially when more than 5 or 10 repositories need to be shown
on the screen.

Using a compact table should allow for 2-3 times more repositories
to be shown in the same space. It's also a more consistent layout,
which makes the list easier to skim through.
