### PR TITLE
Fix for 404 error when comming from project list

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -5,7 +5,7 @@
     #RewriteBase /path/to/gitlist/
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteRule ^(.*)$ index.php [L,NC]
+    RewriteRule ^(.*)$ index.php/$1 [L,NC]
 </IfModule>
 <Files config.ini>
     order allow,deny


### PR DESCRIPTION
This is a simple fix for the rewrite rule not performing the substitution correctly.

Should work more or less out of the box, now.
