### PR TITLE
Allow configuration of the title instead of hardcoding GitList.

### DIFF
--- a/config.ini-example
+++ b/config.ini-example
@@ -14,6 +14,7 @@ repositories[] = '/home/git/repositories/' ; Path to your repositories
 [app]
 debug = false
 cache = true
+title = GitList
 
 ; If you need to specify custom filetypes for certain extensions, do this here
 [filetypes]

--- a/src/GitList/Application.php
+++ b/src/GitList/Application.php
@@ -57,7 +57,8 @@ class Application extends SilexApplication
         $this->register(new UrlGeneratorServiceProvider());
         $this->register(new RoutingUtilServiceProvider());
 
-        $this['twig'] = $this->share($this->extend('twig', function ($twig, $app) {
+        $this['twig'] = $this->share($this->extend('twig', function ($twig, $app) use ($config) {
+            $twig->addGlobal('app_title', $config->get('app', 'title'));
             $twig->addFilter('htmlentities', new \Twig_Filter_Function('htmlentities'));
             $twig->addFilter('md5', new \Twig_Filter_Function('md5'));
 

--- a/views/blame.twig
+++ b/views/blame.twig
@@ -2,7 +2,7 @@
 
 {% set page = 'commits' %}
 
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block content %}
     {% include 'breadcrumb.twig' with {breadcrumbs: [{dir: 'Blame', path:''}]} %}

--- a/views/commit.twig
+++ b/views/commit.twig
@@ -2,7 +2,7 @@
 
 {% set page = 'commits' %}
 
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block content %}
     {% include 'breadcrumb.twig' with {breadcrumbs: [{dir: "Commit #{commit.hash}", path:''}]} %}

--- a/views/commits.twig
+++ b/views/commits.twig
@@ -2,7 +2,7 @@
 
 {% set page = 'commits' %}
 
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block content %}
     {% include 'breadcrumb.twig' with {breadcrumbs: [{dir: 'Commit history', path:''}]} %}

--- a/views/error.twig
+++ b/views/error.twig
@@ -1,5 +1,5 @@
 {% extends 'layout.twig' %}
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block body %}
 {% include 'navigation.twig' %}

--- a/views/file.twig
+++ b/views/file.twig
@@ -2,7 +2,7 @@
 
 {% set page = 'files' %}
 
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block content %}
     {% include 'breadcrumb.twig' with {breadcrumbs: breadcrumbs} %}

--- a/views/index.twig
+++ b/views/index.twig
@@ -1,5 +1,5 @@
 {% extends 'layout.twig' %}
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block body %}
 {% include 'navigation.twig' %}

--- a/views/navigation.twig
+++ b/views/navigation.twig
@@ -6,7 +6,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </a>
-            <a class="brand" href="{{ path('homepage') }}">GitList</a>
+            <a class="brand" href="{{ path('homepage') }}">{{ app_title }}</a>
             <div class="nav-collapse">
                 <ul class="nav pull-right">
                     <li><a href="http://gitlist.org/">About</a></li>

--- a/views/rss.twig
+++ b/views/rss.twig
@@ -2,7 +2,7 @@
 <rss version="2.0">
     <channel>
         <title>Latest commits in {{ repo }}:{{ branch }}</title>
-        <description>RSS provided by GitList</description>
+        <description>RSS provided by {{ app_title }}</description>
         <link>{{ url('homepage') }}</link>
 
         {% for commit in commits %}

--- a/views/search.twig
+++ b/views/search.twig
@@ -2,7 +2,7 @@
 
 {% set page = 'files' %}
 
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block content %}
     {% embed 'breadcrumb.twig' with {breadcrumbs: breadcrumbs} %}

--- a/views/searchcommits.twig
+++ b/views/searchcommits.twig
@@ -2,7 +2,7 @@
 
 {% set page = 'searchcommits' %}
 
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block content %}
     {% include 'breadcrumb.twig' with {breadcrumbs: [{dir: 'Commits search results for: ' ~ query, path:''}]} %}

--- a/views/stats.twig
+++ b/views/stats.twig
@@ -2,7 +2,7 @@
 
 {% set page = 'stats' %}
 
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block content %}
     {% include 'breadcrumb.twig' with {breadcrumbs: [{dir: 'Statistics', path:''}]} %}

--- a/views/tree.twig
+++ b/views/tree.twig
@@ -2,7 +2,7 @@
 
 {% set page = 'files' %}
 
-{% block title %}GitList{% endblock %}
+{% block title %}{{ app_title }}{% endblock %}
 
 {% block content %}
     {% embed 'breadcrumb.twig' with {breadcrumbs: breadcrumbs} %}


### PR DESCRIPTION
`GitList' is hardcoded in most views as page title. This patch use a
  new configuration variable, allowing to customize the titles.
