### PR TITLE
Add SymLinksIfOwnerMatch to .htaccess to squelch Apache RewriteEngine error

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,5 +1,5 @@
 <IfModule mod_rewrite.c>
-    Options -MultiViews
+    Options -MultiViews SymLinksIfOwnerMatch
 
     RewriteEngine On
     #RewriteBase /path/to/gitlist/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ In order to run GitList on your server, you'll need:
 ## Installing
 * Download GitList from [gitlist.org](http://gitlist.org/) and decompress to your `/var/www/gitlist` folder, or anywhere else you want to place GitList. 
 * Rename the `config.ini-example` file to `config.ini`.
-* Open up the `config.ini` and configure your installation. You'll have to provide where your repositories are located and the base GitList URL (in our case, http://localhost/gitlist).
+* Open up the `config.ini` and configure your installation. You'll have to provide where your repositories are located.
+* In case GitList isn't accessed through the root of the website, open .htaccess and edit RewriteBase (for example, /gitlist/ if GitList is accessed through http://localhost/gitlist/).
 * Create the cache folder and give read/write permissions to your web server user:
 
 ```


### PR DESCRIPTION
Apache would show the following error

> [Thu Jul 11 15:15:14 2013] [error] [client ::1] Options FollowSymLinks or SymLinksIfOwnerMatch is off which implies that RewriteRule directive is forbidden: /Users/llunesu/Sites/

SymLinksIfOwnerMatch seems to be the safer of the two, so I added that to .htaccess

Also added a note about .htaccess to the README.md
