### PR TITLE
Fix coverage report

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,11 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
     <logging>
         <log type="coverage-clover" target="build/logs/clover.xml" />
         <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false" />


### PR DESCRIPTION
Fix the coverage report http://ci.gitlist.org:8080/job/GitList%20%28master%29/25/cloverphp-report only generate coverage for project files not for the vendors. This also speed up the coverage report
