### PR TITLE
Directory and its only-child are merged (recursively).

### DIFF
--- a/src/GitList/Controller/TreeController.php
+++ b/src/GitList/Controller/TreeController.php
@@ -14,7 +14,8 @@ class TreeController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get('{repo}/tree/{commitishPath}/', $treeController = function ($repo, $commitishPath = '') use ($app) {
+        $controller = $this;
+        $route->get('{repo}/tree/{commitishPath}/', $treeController = function ($repo, $commitishPath = '') use ($app, $controller) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
             if (!$commitishPath) {
                 $commitishPath = $repository->getHead();
@@ -26,7 +27,7 @@ class TreeController implements ControllerProviderInterface
             $files = $repository->getTree($tree ? "$branch:\"$tree\"/" : $branch);
             $breadcrumbs = $app['util.view']->getBreadcrumbs($tree);
 
-            $this->flattenFolders($files);
+            $controller->flattenFolders($files);
 
             $parent = null;
             if (($slash = strrpos($tree, '/')) !== false) {


### PR DESCRIPTION
Implements a new feature I was missing. It may have little performance overhead (especially for folders with many items), but I found it useful for browsing Java packages. It basically recursively merges a path in the folder tree if all subfolders in the given path have no other siblings. For example if you have src/main/java or package com/project/module/submodule, the whole path is merged so you do not have to click through each subdirectory.

This feature is probably a candidate for discussion.

![screen shot 04-16-14 at 02 50 pm](https://cloud.githubusercontent.com/assets/2247062/2719749/222bc680-c566-11e3-9013-0151d57b89ab.PNG)
