### PR TITLE
Special characters in Commit Name and use another method to escape html char

### DIFF
--- a/views/commit.twig
+++ b/views/commit.twig
@@ -10,7 +10,7 @@
     <div class="commit-view">
         <div class="commit-header">
             <span class="pull-right"><a class="btn btn-small" href="{{ path('branch', {repo: repo, branch: commit.hash}) }}" title="Browse code at this point in history"><i class="icon-list-alt"></i> Browse code</a></span>
-            <h4>{{ commit.message }}</h4>
+            <h4>{{ commit.message|raw }}</h4>
         </div>
         <div class="commit-body">
             {% if commit.body is not empty %}

--- a/views/commits_list.twig
+++ b/views/commits_list.twig
@@ -12,7 +12,7 @@
             <td width="5%"><img src="https://gravatar.com/avatar/{{ item.author.email | lower | md5 }}?s=40" /></td>
             <td width="95%">
                 <span class="pull-right"><a class="btn btn-small" href="{{ path('commit', {repo: repo, commit: item.hash}) }}"><i class="icon-list-alt"></i> View {{ item.shortHash }}</a></span>
-                <h4>{{ item.message }}</h4>
+                <h4>{{ item.message|raw }}</h4>
                 <span><a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored on {{ item.date | date('d/m/Y \\a\\t H:i:s') }}</span>
             </td>
         </tr>


### PR DESCRIPTION
I had encounter some trouble with spécial char (commit name with special char include) when i used this solution
Due of this trouble I have change the method to agregate log/show with git

I hope my patch best meets to the current structure of gitlist

the patch also respond to issue https://github.com/klaussilveira/gitlist/issues/423
