### PR TITLE
Treat possible commit as partial hash as fallback.

### DIFF
--- a/src/GitList/Util/Routing.php
+++ b/src/GitList/Util/Routing.php
@@ -60,20 +60,17 @@ class Routing
 
             if ($matchedBranch !== null) {
                 $commitish = $matchedBranch;
-            }
-            else
-            {
+            } else {
                 // We may have partial commit hash as our commitish.
                 $hash = $slashPosition === false ? $commitishPath : substr($commitishPath, 0, $slashPosition);
                 if ($repository->hasCommit($hash)) {
                     $commit = $repository->getCommit($hash);
                     $commitish = $commit->getHash();
-                }
-                else
+                } else {
                     throw new EmptyRepositoryException('This repository is currently empty. There are no commits.');
+                }
             }
         }
-
 
         $commitishLength = strlen($commitish);
         $path = substr($commitishPath, $commitishLength);


### PR DESCRIPTION
Sometimes full commit hash is not known but there is a need in giving a link to it. This patch adds support for partial commit hashes in URLs, so that links like "http://foo.com/bar.git/commit/ea42cd12f9" work.
