### PR TITLE
Sort commits by date in descending order

### DIFF
--- a/src/GitList/Controller/CommitController.php
+++ b/src/GitList/Controller/CommitController.php
@@ -40,7 +40,7 @@ class CommitController implements ControllerProviderInterface
 
             foreach ($commits as $commit) {
                 $date = $commit->getDate();
-                $date = $date->format('m/d/Y');
+                $date = $date->format('Y-m-d');
                 $categorized[$date][] = $commit;
             }
 
@@ -72,7 +72,7 @@ class CommitController implements ControllerProviderInterface
 
             foreach ($commits as $commit) {
                 $date = $commit->getDate();
-                $date = $date->format('m/d/Y');
+                $date = $date->format('Y-m-d');
                 $categorized[$date][] = $commit;
             }
 


### PR DESCRIPTION
Commit day could be in the past compared to push day (e.g. when rebase
took place). This leads to invalid order of days in /commits and
/commits/search routes. This patch sorts categorized commits so that order
is always descending.
