### PR TITLE
Allow replacing GitList's title by another defined in config.ini

### DIFF
--- a/config.ini-example
+++ b/config.ini-example
@@ -15,6 +15,7 @@ repositories[] = '/home/git/repositories/' ; Path to your repositories
 debug = false
 cache = true
 theme = "default"
+title = ""
 
 ; If you need to specify custom filetypes for certain extensions, do this here
 [filetypes]

--- a/src/GitList/Application.php
+++ b/src/GitList/Application.php
@@ -33,6 +33,7 @@ class Application extends SilexApplication
         $this['debug'] = $config->get('app', 'debug');
         $this['date.format'] = $config->get('date', 'format') ? $config->get('date', 'format') : 'd/m/Y H:i:s';
         $this['theme'] = $config->get('app', 'theme') ? $config->get('app', 'theme') : 'default';
+        $this['title'] = $config->get('app', 'title') ? $config->get('app', 'title') : 'GitList';
         $this['filetypes'] = $config->getSection('filetypes');
         $this['binary_filetypes'] = $config->getSection('binary_filetypes');
         $this['cache.archives'] = $this->getCachePath() . 'archives';

--- a/themes/default/twig/layout.twig
+++ b/themes/default/twig/layout.twig
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
-        <title>{% block title %}Welcome!{% endblock %}</title>
+        <title>{{ app.title }}{% if app.title %} - {% endif %}{% block title %}Welcome!{% endblock %}</title>
         <link rel="stylesheet" type="text/css" href="{{ app.request.basepath }}/themes/{{ app.theme }}/css/style.css">
         <link rel="shortcut icon" type="image/png" href="{{ app.request.basepath }}/themes/{{ app.theme }}/img/favicon.png" />
         <!--[if lt IE 9]>

--- a/themes/default/twig/navigation.twig
+++ b/themes/default/twig/navigation.twig
@@ -6,7 +6,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </a>
-            <a class="brand" href="{{ path('homepage') }}">GitList</a>
+            <a class="brand" href="{{ path('homepage') }}">{{ app.title }}</a>
             <div class="nav-collapse">
                 <ul class="nav pull-right">
                     <li><a href="http://gitlist.org/">About</a></li>


### PR DESCRIPTION
As I set up many GitLists, I thought it was a good idea to define a title shown on the top instead of GitList's so I can make the difference easier between each of them.

The title can be defined in config.php and will be also shown in the browser's tab. If it isn't given, "GitList" will be defined by default.

![capture d cran de 2014-06-30 17 33 34](https://cloud.githubusercontent.com/assets/930282/3431619/21580714-006c-11e4-8dc0-1e6546761204.png)

![capture d cran de 2014-06-30 17 36 55](https://cloud.githubusercontent.com/assets/930282/3431648/6f4a5ab2-006c-11e4-84a1-ea911e1f2888.png)
