### PR TITLE
Take branch into account when searching for commit

### DIFF
--- a/src/GitList/Controller/CommitController.php
+++ b/src/GitList/Controller/CommitController.php
@@ -68,7 +68,7 @@ class CommitController implements ControllerProviderInterface
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
             $query = $request->get('query');
 
-            $commits = $repository->searchCommitLog($request->get('query'));
+            $commits = $repository->searchCommitLog($query, $branch);
             $categorized = array();
 
             foreach ($commits as $commit) {

--- a/src/GitList/Git/Repository.php
+++ b/src/GitList/Git/Repository.php
@@ -238,7 +238,7 @@ class Repository extends BaseRepository
         return $commits;
     }
 
-    public function searchCommitLog($query)
+    public function searchCommitLog($query, $branch)
     {
         $query = escapeshellarg($query);
         $query = strtr($query, array('[' => '\\[', ']' => '\\]'));
@@ -249,7 +249,8 @@ class Repository extends BaseRepository
             . "<date>%at</date><commiter>%cn</commiter>"
             . "<commiter_email>%ce</commiter_email>"
             . "<commiter_date>%ct</commiter_date>"
-            . "<message><![CDATA[%s]]></message></item>\"";
+            . "<message><![CDATA[%s]]></message></item>\""
+            . " $branch";
 
         try {
             $logs = $this->getPrettyFormat($command);


### PR DESCRIPTION
When in /commits and doing a search, branch is never taken into account and 'master' is used. Pass branch name to `log` so that search is performed within current branch.
