### PR TITLE
Show committer if it differs from author

### DIFF
--- a/themes/bootstrap3/twig/commit.twig
+++ b/themes/bootstrap3/twig/commit.twig
@@ -18,7 +18,13 @@
             <p>{{ commit.body | nl2br }}</p>
             {% endif %}
             <img src="https://gravatar.com/avatar/{{ commit.author.email | lower | md5 }}?s=32" class="pull-left space-right" />
-            <span><a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}<br />Showing {{ commit.changedFiles }} changed files</span>
+            <span>
+                <a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}
+                {% if commit.author.email != commit.commiter.email %}
+                &bull; <a href="mailto:{{ commit.commiter.email }}">{{ commit.commiter.name }}</a> committed on {{ commit.commiterDate | format_date }}
+                {% endif %}
+                <br />Showing {{ commit.changedFiles }} changed files
+            </span>
         </div>
     </div>
 

--- a/themes/bootstrap3/twig/commits_list.twig
+++ b/themes/bootstrap3/twig/commits_list.twig
@@ -13,7 +13,12 @@
             <td width="95%">
                 <span class="pull-right"><a class="btn btn-default btn-sm" href="{{ path('commit', {repo: repo, commit: item.hash}) }}"><span class="fa fa-list-alt"></span> View {{ item.shortHash }}</a></span>
                 <h4>{{ item.message }}</h4>
-                <span><a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored on {{ item.date | format_date }}</span>
+                <span>
+                    <a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored on {{ item.date | format_date }}
+                    {% if item.author.email != item.commiter.email %}
+                    &bull; <a href="mailto:{{ item.commiter.email }}">{{ item.commiter.name }}</a> committed on {{ item.commiterDate | format_date }}
+                    {% endif %}
+                </span>
             </td>
         </tr>
         {% endfor %}

--- a/themes/default/twig/commit.twig
+++ b/themes/default/twig/commit.twig
@@ -17,7 +17,13 @@
             <p>{{ commit.body | nl2br }}</p>
             {% endif %}
             <img src="https://gravatar.com/avatar/{{ commit.author.email | lower | md5 }}?s=32" class="pull-left space-right" />
-            <span><a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}<br />Showing {{ commit.changedFiles }} changed files</span>
+            <span>
+                <a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}
+                {% if commit.author.email != commit.commiter.email %}
+                &bull; <a href="mailto:{{ commit.commiter.email }}">{{ commit.commiter.name }}</a> committed on {{ commit.commiterDate | format_date }}
+                {% endif %}
+                <br />Showing {{ commit.changedFiles }} changed files
+            </span>
         </div>
     </div>
 

--- a/themes/default/twig/commits_list.twig
+++ b/themes/default/twig/commits_list.twig
@@ -13,7 +13,12 @@
             <td width="95%">
                 <span class="pull-right"><a class="btn btn-small" href="{{ path('commit', {repo: repo, commit: item.hash}) }}"><i class="icon-list-alt"></i> View {{ item.shortHash }}</a></span>
                 <h4>{{ item.message }}</h4>
-                <span><a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored on {{ item.date | format_date }}</span>
+                <span>
+                    <a href="mailto:{{ item.author.email }}">{{ item.author.name }}</a> authored on {{ item.date | format_date }}
+                    {% if item.author.email != item.commiter.email %}
+                    &bull; <a href="mailto:{{ item.commiter.email }}">{{ item.commiter.name }}</a> committed on {{ item.commiterDate | format_date }}
+                    {% endif %}
+                </span>
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
It is quite useful sometimes to see that someone else (not you) has pushed
commit to remote. This change adds "C committed on D" phrase right after
"A authored on B" if author and committer are not the same person (judging
from email address).
