### PR TITLE
Made search functions case insensitive

### DIFF
--- a/src/GitList/Git/Repository.php
+++ b/src/GitList/Git/Repository.php
@@ -271,7 +271,7 @@ class Repository extends BaseRepository
         $query = escapeshellarg($query);
 
         try {
-            $results = $this->getClient()->run($this, "grep -I --line-number {$query} $branch");
+            $results = $this->getClient()->run($this, "grep -i --line-number {$query} $branch");
         } catch (\RuntimeException $e) {
             return false;
         }


### PR DESCRIPTION
When searching the commit log, it's nice to be case-insensitive when you don't know the exact capitalisation of what you're looking for.
