### PR TITLE
getBlame: PHP_EOL should be at the end of the line

### DIFF
--- a/src/GitList/Git/Repository.php
+++ b/src/GitList/Git/Repository.php
@@ -105,7 +105,7 @@ class Repository extends BaseRepository
                 );
             }
 
-            $blame[$i]['line'] .= PHP_EOL . $match[3][0];
+            $blame[$i]['line'] .= $match[3][0] . PHP_EOL;
             $previousCommit = $currentCommit;
         }
 


### PR DESCRIPTION
Noticed this whilst designing my own theme for GitList. This has no effect on the default or bootstrap3 themes' blame view, as display of newlines seems to be different between their `<pre>` tags and my theme's `<samp>` tags.
