### PR TITLE
Give archive downloads a more descriptive filename. Fixes #503

### DIFF
--- a/src/GitList/Controller/TreeController.php
+++ b/src/GitList/Controller/TreeController.php
@@ -94,7 +94,7 @@ class TreeController implements ControllerProviderInterface
             }
 
             $res = new BinaryFileResponse($file);
-            $res->setContentDisposition('attachment', $repo . '.' . $branch . '.' . $format);
+            $res->setContentDisposition('attachment', basename($repo) . '.' . $branch . '.' . $format);
 
             return $res;
         })->assert('format', '(zip|tar)')


### PR DESCRIPTION
When you click the zip/tar download buttons, the filename shown is simply the branch or commit hash with no extension (eg. `master`). This adds the repo name and file extension to the HTTP response, giving something like `gitlist.master.tar`.

EDIT: Title didn't auto-reference issue #503.
