### PR TITLE
Nicer looking diff anchor targets

### DIFF
--- a/themes/bootstrap3/twig/commit.twig
+++ b/themes/bootstrap3/twig/commit.twig
@@ -24,14 +24,14 @@
 
     <ul class="commit-list">
         {% for diff in commit.diffs %}
-            <li><i class="fa fa-file"></i> <a href="#{{ loop.index }}">{{ diff.file }}</a> <span class="meta pull-right">{{ diff.index }}</span></li>
+            <li><i class="fa fa-file"></i> <a href="#diff-{{ loop.index }}">{{ diff.file }}</a> <span class="meta pull-right">{{ diff.index }}</span></li>
         {% endfor %}
     </ul>
 
     {% for diff in commit.diffs %}
     <div class="source-view">
         <div class="source-header">
-            <div class="meta"><a name="{{ loop.index }}">{{ diff.file }}</div>
+            <div class="meta"><a id="diff-{{ loop.index }}">{{ diff.file }}</div>
 
             <div class="btn-group pull-right">
                 <a href="{{ path('commits', {repo: repo, commitishPath: commit.hash ~ '/' ~ diff.file}) }}"  class="btn btn-default btn-sm"><span class="fa fa-list-alt"></span> History</a>

--- a/themes/default/twig/commit.twig
+++ b/themes/default/twig/commit.twig
@@ -23,14 +23,14 @@
 
     <ul class="commit-list">
         {% for diff in commit.diffs %}
-            <li><i class="icon-file"></i> <a href="#{{ loop.index }}">{{ diff.file }}</a> <span class="meta pull-right">{{ diff.index }}</span></li>
+            <li><i class="icon-file"></i> <a href="#diff-{{ loop.index }}">{{ diff.file }}</a> <span class="meta pull-right">{{ diff.index }}</span></li>
         {% endfor %}
     </ul>
 
     {% for diff in commit.diffs %}
     <div class="source-view">
         <div class="source-header">
-            <div class="meta"><a name="{{ loop.index }}">{{ diff.file }}</div>
+            <div class="meta"><a id="diff-{{ loop.index }}">{{ diff.file }}</div>
 
             <div class="btn-group pull-right">
                 <a href="{{ path('commits', {repo: repo, commitishPath: commit.hash ~ '/' ~ diff.file}) }}" class="btn btn-small"><i class="icon-list-alt"></i> History</a>


### PR DESCRIPTION
In HTML5 the `name` attribute for anchor tags has been removed (although it still works in most if not all browsers). Use `id` instead and prepend "diff-" to show that the url leads to a diff, eg. http://gitlistserver/repo/commit/1234567/#diff-1
