### PR TITLE
Problem with tree path containing spaces

### DIFF
--- a/src/GitList/Util/Repository.php
+++ b/src/GitList/Util/Repository.php
@@ -172,7 +172,7 @@ class Repository
 
         if ($path != "") $path = "$path/";
 
-        $files = $repository->getTree($path != "" ? "$branch:$path" : $branch)->output();
+        $files = $repository->getTree($path != "" ? "$branch:\"$path\"" : $branch)->output();
 
         foreach ($files as $file) {
             if (preg_match('/^readme*/i', $file['name'])) {


### PR DESCRIPTION
Paths should be protected with quotes in case of spaces

Fixes #518
