### PR TITLE
#524 gitlist not showing all repositories

### DIFF
--- a/themes/default/js/main.js
+++ b/themes/default/js/main.js
@@ -44,7 +44,8 @@ $(function () {
 
 if ($('#repositories').length) {
     var listOptions = {
-        valueNames: ['name']
+        valueNames: ['name'],
+        page: 500
     };
     var repoList = new List('repositories', listOptions);
 }


### PR DESCRIPTION
This is a fix for the problem that gitlist only shows the first 200 repos.

The problem is that the default number of items shown by List.js is 200. This patch increases the number of displayed repos to 500.