### PR TITLE
remove Util/Repository::extractRef()

### DIFF
--- a/src/GitList/Controller/BlobController.php
+++ b/src/GitList/Controller/BlobController.php
@@ -18,8 +18,6 @@ class BlobController implements ControllerProviderInterface
             list($branch, $file) = $app['util.routing']
                 ->parseCommitishPathParam($commitishPath, $repo);
 
-            list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
-
             $blob = $repository->getBlob("$branch:\"$file\"");
             $breadcrumbs = $app['util.view']->getBreadcrumbs($file);
             $fileType = $app['util.repository']->getFileType($file);
@@ -51,8 +49,6 @@ class BlobController implements ControllerProviderInterface
 
             list($branch, $file) = $app['util.routing']
                 ->parseCommitishPathParam($commitishPath, $repo);
-
-            list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
 
             $blob = $repository->getBlob("$branch:\"$file\"")->output();
 

--- a/src/GitList/Controller/CommitController.php
+++ b/src/GitList/Controller/CommitController.php
@@ -31,8 +31,6 @@ class CommitController implements ControllerProviderInterface
             list($branch, $file) = $app['util.routing']
                 ->parseCommitishPathParam($commitishPath, $repo);
 
-            list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
-
             $type = $file ? "$branch -- \"$file\"" : $branch;
             $pager = $app['util.view']->getPager($app['request']->get('page'), $repository->getTotalCommits($type));
             $commits = $repository->getPaginatedCommits($type, $pager['current']);
@@ -108,8 +106,6 @@ class CommitController implements ControllerProviderInterface
 
             list($branch, $file) = $app['util.routing']
                 ->parseCommitishPathParam($commitishPath, $repo);
-
-            list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
 
             $blames = $repository->getBlame("$branch -- \"$file\"");
 

--- a/src/GitList/Controller/NetworkController.php
+++ b/src/GitList/Controller/NetworkController.php
@@ -106,7 +106,6 @@ class NetworkController implements ControllerProviderInterface
                 }
 
                 list($branch, $file) = $app['util.routing']->parseCommitishPathParam($commitishPath, $repo);
-                list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
 
                 return $app['twig']->render(
                     'network.twig',

--- a/src/GitList/Controller/TreeController.php
+++ b/src/GitList/Controller/TreeController.php
@@ -21,7 +21,6 @@ class TreeController implements ControllerProviderInterface
 
             list($branch, $tree) = $app['util.routing']->parseCommitishPathParam($commitishPath, $repo);
 
-            list($branch, $tree) = $app['util.repository']->extractRef($repository, $branch, $tree);
             $files = $repository->getTree($tree ? "$branch:\"$tree\"/" : $branch);
             $breadcrumbs = $app['util.view']->getBreadcrumbs($tree);
 

--- a/src/GitList/Util/Repository.php
+++ b/src/GitList/Util/Repository.php
@@ -186,44 +186,5 @@ class Repository
 		if ($path != "") return $this->getReadme($repository, $branch, "");
         return array();
     }
-
-    /**
-     * Returns an Array where the first value is the tree-ish and the second is the path
-     *
-     * @param  \GitList\Git\Repository $repository
-     * @param  string                  $branch
-     * @param  string                  $tree
-     * @return array
-     */
-    public function extractRef($repository, $branch = '', $tree = '')
-    {
-        $branch = trim($branch, '/');
-        $tree = trim($tree, '/');
-        $input = $branch . '/' . $tree;
-
-        // If the ref appears to be a SHA, just split the string
-        if (preg_match("/^([[:alnum:]]{40})(.+)/", $input, $matches)) {
-            $branch = $matches[1];
-        } else {
-            // Otherwise, attempt to detect the ref using a list of the project's branches and tags
-            $validRefs = array_merge((array) $repository->getBranches(), (array) $repository->getTags());
-            foreach ($validRefs as $key => $ref) {
-                if (!preg_match(sprintf("#^%s/#", preg_quote($ref, '#')), $input)) {
-                    unset($validRefs[$key]);
-                }
-            }
-
-            // No exact ref match, so just try our best
-            if (count($validRefs) > 1) {
-                preg_match('/([^\/]+)(.*)/', $input, $matches);
-                $branch = preg_replace('/^\/|\/$/', '', $matches[1]);
-            } else {
-                // Extract branch name
-                $branch = array_shift($validRefs);
-            }
-        }
-
-        return array($branch, $tree);
-    }
 }
 


### PR DESCRIPTION
- remove dup code (Util/Routing::parseCommitishPathParam() is good)
- also fix wrong handling for repository with dash-named branches
  eg. for both branches "a" and "a/b", gitlist only show "a"
  when "a/b" is selected.
