### PR TITLE
Add support for gitweb-style projects.list

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -48,6 +48,9 @@ class Application extends SilexApplication
         ));
 
         $repositories = $config->get('git', 'repositories');
+        $this['git.projects'] = $config->get('git', 'project_list') ?
+                                $this->parseProjectList($config->get('git', 'project_list')) :
+                                false;
 
         $this->register(new GitServiceProvider(), array(
             'git.client'         => $config->get('git', 'client'),
@@ -152,5 +155,15 @@ class Application extends SilexApplication
             . DIRECTORY_SEPARATOR
             . 'twig'
             . DIRECTORY_SEPARATOR;
+    }
+
+    public function parseProjectList($project_list)
+    {
+        $projects = array();
+        $file = fopen($project_list, "r");
+        while ($file && !feof($file))
+            $projects[] = trim(fgets($file));
+        fclose($file);
+        return $projects;
     }
 }

--- a/src/Git/Client.php
+++ b/src/Git/Client.php
@@ -8,12 +8,14 @@ class Client extends BaseClient
 {
     protected $defaultBranch;
     protected $hidden;
+    protected $projects;
 
     public function __construct($options = null)
     {
         parent::__construct($options['path']);
         $this->setDefaultBranch($options['default_branch']);
         $this->setHidden($options['hidden']);
+        $this->setProjects($options['projects']);
     }
 
     public function getRepositoryFromName($paths, $repo)
@@ -102,6 +104,10 @@ class Client extends BaseClient
                         $repoName = $file->getFilename();
                     }
 
+                    if (is_array($this->getProjects()) && !in_array($repoName, $this->getProjects())) {
+                        continue;
+                    }
+
                     $repositories[$repoName] = array(
                         'name' => $repoName,
                         'path' => $file->getPathname(),
@@ -158,6 +164,28 @@ class Client extends BaseClient
     protected function setHidden($hidden)
     {
         $this->hidden = $hidden;
+
+        return $this;
+    }
+
+    /**
+     * Get project list
+     *
+     * @return array List of repositories to show
+     */
+    protected function getProjects()
+    {
+        return $this->projects;
+    }
+
+    /**
+     * Set the shown repository list
+     *
+     * @param array $projects List of repositories to show
+     */
+    protected function setProjects($projects)
+    {
+        $this->projects = $projects;
 
         return $this;
     }

--- a/src/Provider/GitServiceProvider.php
+++ b/src/Provider/GitServiceProvider.php
@@ -20,6 +20,7 @@ class GitServiceProvider implements ServiceProviderInterface
         $app['git'] = function () use ($app) {
             $options['path'] = $app['git.client'];
             $options['hidden'] = $app['git.hidden'];
+            $options['projects'] = $app['git.projects'];
             $options['ini.file'] = $app['ini.file'];
             $options['default_branch'] = $app['git.default_branch'];
 


### PR DESCRIPTION
It's useful to have web UI display only repositories with configured public access. This is particularly important when hosting git using http://gitolite.com/gitolite/index.html or similar solutions.

In case of gitolite, public visibility is controlled by giving access to a special user called "gitweb". This makes gitolite add the repository to projects.list file, which is read by gitweb (https://www.kernel.org/pub/software/scm/git/docs/gitweb.conf.html variable $projects_list).

I've added an option to point gitlist to the same file. If the file exists, only repositories listed there will be shown.