### PR TITLE
Update version number using Composer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ config.ini
 cache.properties
 composer.phar
 phpunit.xml
+/version

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,10 @@
         "psr-0": {
             "GitList": "src/"
         }
+    },
+    "scripts": {
+        "update-version": [
+            "git describe --always --long > version"
+        ]
     }
 }

--- a/src/GitList/Application.php
+++ b/src/GitList/Application.php
@@ -17,6 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class Application extends SilexApplication
 {
     protected $path;
+    protected $version;
 
     /**
      * Constructor initialize services.
@@ -29,6 +30,9 @@ class Application extends SilexApplication
         parent::__construct();
         $app = $this;
         $this->path = realpath($root);
+        if (is_readable($root . '/version')) {
+            $this->version = file_get_contents($root . '/version');
+        }
 
         $this['debug'] = $config->get('app', 'debug');
         $this['date.format'] = $config->get('date', 'format') ? $config->get('date', 'format') : 'd/m/Y H:i:s';
@@ -67,6 +71,7 @@ class Application extends SilexApplication
             $twig->addFilter(new \Twig_SimpleFilter('md5', 'md5'));
             $twig->addFilter(new \Twig_SimpleFilter('format_date', array($app, 'formatDate')));
             $twig->addFilter(new \Twig_SimpleFilter('format_size', array($app, 'formatSize')));
+            $twig->addGlobal('gitlist_version', $this->version);
 
             return $twig;
         }));

--- a/themes/default/twig/footer.twig
+++ b/themes/default/twig/footer.twig
@@ -1,3 +1,3 @@
 <footer>
-    <p>Powered by <a href="https://github.com/klaussilveira/gitlist">GitList 0.5.0</a></p>
+    <p>Powered by <a href="https://github.com/klaussilveira/gitlist">GitList {{ gitlist_version }}</a></p>
 </footer>


### PR DESCRIPTION
It's recommended to add `post-commit` and `post-checkout` hooks to
invoke the command `composer update-version`.