### PR TITLE
Update README.md (fix screenshots)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ GitList is an elegant and modern web interface for interacting with multiple git
 * Repository statistics
 
 ## Screenshots
-[![GitList Screenshot](http://dl.dropbox.com/u/62064441/th1.jpg)](http://cloud.github.com/downloads/klaussilveira/gitlist/1.jpg)
-[![GitList Screenshot](http://dl.dropbox.com/u/62064441/th2.jpg)](http://cloud.github.com/downloads/klaussilveira/gitlist/2.jpg)
-[![GitList Screenshot](http://dl.dropbox.com/u/62064441/th3.jpg)](http://cloud.github.com/downloads/klaussilveira/gitlist/3.jpg)
-[![GitList Screenshot](http://dl.dropbox.com/u/62064441/th4.jpg)](http://cloud.github.com/downloads/klaussilveira/gitlist/4.jpg)
-[![GitList Screenshot](http://dl.dropbox.com/u/62064441/th5.jpg)](http://cloud.github.com/downloads/klaussilveira/gitlist/5.jpg)
+<img src="http://klaussilveira.com/gitlist/img/roller/1.jpg" alt="GitList Screenshot" width="200" />
+<img src="http://klaussilveira.com/gitlist/img/roller/2.jpg" alt="GitList Screenshot" width="200" />
+<img src="http://klaussilveira.com/gitlist/img/roller/3.jpg" alt="GitList Screenshot" width="200" />
+
 
 You can also see a live demo [here](http://gitlist-khornberg.rhcloud.com/).
 


### PR DESCRIPTION
Fixing the screenshot links. The old ones could not be linked to for some reason (I suspect GitHub changing markdown requirements).

The new ones pull from what looks like the carousel from the gh-pages branch.