### PR TITLE
Fixes an issue with stats in paths with whitespace

### DIFF
--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -344,9 +344,13 @@ class Repository extends BaseRepository
             if (is_numeric($file[3])) {
                 $data['size'] += $file[3];
             }
+        }
 
-            if (($pos = strrpos($file[4], '.')) !== false) {
-                $extension = substr($file[4], $pos);
+        $logs = $this->getClient()->run($this, 'ls-tree -l -r --name-only ' . $branch);
+        $files = explode("\n", $logs);
+        foreach ($files as $file) {
+            if (($pos = strrpos($file, '.')) !== false) {
+                $extension = substr($file, $pos);
 
                 if (($pos = strrpos($extension, '/')) === false) {
                     $data['extensions'][] = $extension;


### PR DESCRIPTION
Splitting on whitespace of the ls-tree output is not enough: when
a path contains a space only the first part is taken as the file
name. This commit changes that behaviour by using another command
to list all the file names.

For an example, take https://git.camilstaps.nl/NWI-IBI008-Data-Mining.git/stats/master. If you look at the files in the repo, you see there are many .py files (for instance), but they don't appear in the extension stats because they're in directories that contain spaces ("Assignment 1", etc.).