### PR TITLE
- Fixed empty tree searches

### DIFF
--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -271,6 +271,10 @@ class Repository extends BaseRepository
 
     public function searchTree($query, $branch)
     {
+        if(empty($query)) {
+			return null;
+		}
+        
         $query = escapeshellarg($query);
 
         try {


### PR DESCRIPTION
Tree searches resulted in a PHP warning if the string was empty