### PR TITLE
Update bootstrap3 theme so it displays app.title.

### DIFF
--- a/themes/bootstrap3/twig/navigation.twig
+++ b/themes/bootstrap3/twig/navigation.twig
@@ -7,7 +7,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{{ path('homepage') }}">GitList</a>
+            <a class="navbar-brand" href="{{ path('homepage') }}">{{ app.title }}</a>
         </div>
         <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav navbar-right">


### PR DESCRIPTION
When trying out the "bootstrap3" theme, I noticed it did not display app.title as the default theme does. The fix is rather trivial and I hereby submit it for merging into master.