### PR TITLE
Gitolite integration with GitList

### DIFF
--- a/bin/gitolite-perms.sh
+++ b/bin/gitolite-perms.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Get list of available repositories for GL_USER.
+#
+# !! security warning !!
+# 1) set owner:group to GITOLITE_USER:GITOLITE_GROUP
+#    !! it is important that HTTPD_USER is not owner of this script !!
+# 2) set permissions to 0700
+#    !! it is important that HTTPD_USER doesn't have ANY permissions !!
+
+export GITOLITE_HOME="/home/git" # path to gitolite's home directory
+
+${GITOLITE_HOME}/bin/gitolite info -json

--- a/bin/gitolite-wrapper.sh
+++ b/bin/gitolite-wrapper.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Wrapper for gitolite calls.
+#
+# !! security warning !!
+# 1) allow HTTPD_USER to be able to run ONLY DOCUMENT_ROOT/bin/gitolite-perms.sh via sudo
+# 2) set owner:group to GITOLITE_USER:HTTPD_USER_GROUP
+#    !! it is important that HTTPD_USER is not owner of this script !!
+# 3) set permissions to 0750
+#    !! it is important that HTTPD_USER doesn't have write permissions !!
+
+if [[ $# -ne 1 ]]; then
+    >&2 echo "You have to pass username as argument."
+    exit 1
+fi
+
+GITOLITE_USER="git" # user which gitolite is running under
+GITOLITE_PERMS_WRAPPER="/var/www/gitlist/bin/gitolite-perms.sh" # path to DOCUMENT_ROOT/bin/gitolite-perms.sh
+
+sudo -u ${GITOLITE_USER} GL_USER="$1" ${GITOLITE_PERMS_WRAPPER}

--- a/config.ini-example
+++ b/config.ini-example
@@ -30,6 +30,11 @@ url_subdir = 'git/' ; if cloning via HTTP is triggered using virtual dir (e.g. h
 http_user = '' ; user to use for cloning via HTTP (default: none)
 http_user_dynamic = false ; when enabled, http_user is set to $_SERVER['PHP_AUTH_USER']
 
+; gitolite integration
+[gitolite]
+active = false ; activates personalized view of available repositories
+wrapper_path = '/var/www/gitlist/bin/gitolite-wrapper.sh' ; path to DOCUMENT_ROOT/bin/gitolite-wrapper.sh
+
 ; If you need to specify custom filetypes for certain extensions, do this here
 [filetypes]
 ; extension = type

--- a/src/Application.php
+++ b/src/Application.php
@@ -45,6 +45,7 @@ class Application extends SilexApplication
         $this['http_user'] = $config->get('clone_button', 'http_user_dynamic') ? $_SERVER['PHP_AUTH_USER'] : $config->get('clone_button', 'http_user');
         $this['show_ssh_remote'] = $config->get('clone_button', 'show_ssh_remote');
         $this['ssh_user'] = $config->get('clone_button', 'ssh_user');
+        $this['username'] = $config->get('gitolite', 'active') ? $_SERVER['PHP_AUTH_USER'] : NULL;
 
         // Register services
         $this->register(new TwigServiceProvider(), array(
@@ -59,13 +60,16 @@ class Application extends SilexApplication
                                 false;
 
         $this->register(new GitServiceProvider(), array(
-            'git.client'         => $config->get('git', 'client'),
-            'git.repos'          => $repositories,
-            'ini.file'           => "config.ini",
-            'git.hidden'         => $config->get('git', 'hidden') ?
-                                    $config->get('git', 'hidden') : array(),
-            'git.default_branch' => $config->get('git', 'default_branch') ?
-                                    $config->get('git', 'default_branch') : 'master',
+            'git.client'            => $config->get('git', 'client'),
+            'git.repos'             => $repositories,
+            'ini.file'              => "config.ini",
+            'git.hidden'            => $config->get('git', 'hidden') ?
+                                       $config->get('git', 'hidden') : array(),
+            'git.default_branch'    => $config->get('git', 'default_branch') ?
+                                       $config->get('git', 'default_branch') : 'master',
+            'gitolite.active'       => $config->get('gitolite', 'active'),
+            'gitolite.wrapper_path' => $config->get('gitolite', 'wrapper_path'),
+            'username'              => $this['username'],
         ));
 
         $this->register(new ViewUtilServiceProvider());

--- a/src/Controller/BlobController.php
+++ b/src/Controller/BlobController.php
@@ -5,6 +5,7 @@ namespace GitList\Controller;
 use Silex\Application;
 use Silex\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\Response;
+use GitList\Exception\NoRepositoryException;
 
 class BlobController implements ControllerProviderInterface
 {
@@ -12,63 +13,66 @@ class BlobController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get('{repo}/blob/{commitishPath}', function ($repo, $commitishPath) use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+        try {
+            $route->get('{repo}/blob/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
-            list($branch, $file) = $app['util.routing']
-                ->parseCommitishPathParam($commitishPath, $repo);
+                list($branch, $file) = $app['util.routing']
+                    ->parseCommitishPathParam($commitishPath, $repo);
 
-            list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
+                list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
 
-            $blob = $repository->getBlob("$branch:\"$file\"");
-            $breadcrumbs = $app['util.view']->getBreadcrumbs($file);
-            $fileType = $app['util.repository']->getFileType($file);
+                $blob = $repository->getBlob("$branch:\"$file\"");
+                $breadcrumbs = $app['util.view']->getBreadcrumbs($file);
+                $fileType = $app['util.repository']->getFileType($file);
 
-            if ($fileType !== 'image' && $app['util.repository']->isBinary($file)) {
-                return $app->redirect($app['url_generator']->generate('blob_raw', array(
-                    'repo'   => $repo,
-                    'commitishPath' => $commitishPath,
-                )));
-            }
+                if ($fileType !== 'image' && $app['util.repository']->isBinary($file)) {
+                    return $app->redirect($app['url_generator']->generate('blob_raw', array(
+                        'repo'   => $repo,
+                        'commitishPath' => $commitishPath,
+                    )));
+                }
 
-            return $app['twig']->render('file.twig', array(
-                'file'           => $file,
-                'fileType'       => $fileType,
-                'blob'           => $blob->output(),
-                'repo'           => $repo,
-                'branch'         => $branch,
-                'breadcrumbs'    => $breadcrumbs,
-                'branches'       => $repository->getBranches(),
-                'tags'           => $repository->getTags(),
-            ));
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('commitishPath', '.+')
-          ->convert('commitishPath', 'escaper.argument:escape')
-          ->bind('blob');
+                return $app['twig']->render('file.twig', array(
+                    'file'           => $file,
+                    'fileType'       => $fileType,
+                    'blob'           => $blob->output(),
+                    'repo'           => $repo,
+                    'branch'         => $branch,
+                    'breadcrumbs'    => $breadcrumbs,
+                    'branches'       => $repository->getBranches(),
+                    'tags'           => $repository->getTags(),
+                ));
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('commitishPath', '.+')
+              ->convert('commitishPath', 'escaper.argument:escape')
+              ->bind('blob');
 
-        $route->get('{repo}/raw/{commitishPath}', function ($repo, $commitishPath) use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+            $route->get('{repo}/raw/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
-            list($branch, $file) = $app['util.routing']
-                ->parseCommitishPathParam($commitishPath, $repo);
+                list($branch, $file) = $app['util.routing']
+                    ->parseCommitishPathParam($commitishPath, $repo);
 
-            list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
+                list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
 
-            $blob = $repository->getBlob("$branch:\"$file\"")->output();
+                $blob = $repository->getBlob("$branch:\"$file\"")->output();
 
-            $headers = array();
-            if ($app['util.repository']->isBinary($file)) {
-                $headers['Content-Disposition'] = 'attachment; filename="' .  $file . '"';
-                $headers['Content-Type'] = 'application/octet-stream';
-            } else {
-                $headers['Content-Type'] = 'text/plain';
-            }
+                $headers = array();
+                if ($app['util.repository']->isBinary($file)) {
+                    $headers['Content-Disposition'] = 'attachment; filename="' .  $file . '"';
+                    $headers['Content-Type'] = 'application/octet-stream';
+                } else {
+                    $headers['Content-Type'] = 'text/plain';
+                }
 
-            return new Response($blob, 200, $headers);
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
-          ->convert('commitishPath', 'escaper.argument:escape')
-          ->bind('blob_raw');
+                return new Response($blob, 200, $headers);
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
+              ->convert('commitishPath', 'escaper.argument:escape')
+              ->bind('blob_raw');
+        } catch(NoRepositoryException $e) {
+        }
 
         return $route;
     }

--- a/src/Controller/CommitController.php
+++ b/src/Controller/CommitController.php
@@ -5,6 +5,7 @@ namespace GitList\Controller;
 use Silex\Application;
 use Silex\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use GitList\Exception\NoRepositoryException;
 
 class CommitController implements ControllerProviderInterface
 {
@@ -12,119 +13,122 @@ class CommitController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get('{repo}/commits/search', function (Request $request, $repo) use ($app) {
-            $subRequest = Request::create(
-                '/' . $repo . '/commits/master/search',
-                'POST',
-                array('query' => $request->get('query'))
-            );
-            return $app->handle($subRequest, \Symfony\Component\HttpKernel\HttpKernelInterface::SUB_REQUEST);
-        })->assert('repo', $app['util.routing']->getRepositoryRegex());
+        try {
+            $route->get('{repo}/commits/search', function (Request $request, $repo) use ($app) {
+                $subRequest = Request::create(
+                    '/' . $repo . '/commits/master/search',
+                    'POST',
+                    array('query' => $request->get('query'))
+                );
+                return $app->handle($subRequest, \Symfony\Component\HttpKernel\HttpKernelInterface::SUB_REQUEST);
+            })->assert('repo', $app['util.routing']->getRepositoryRegex());
 
-        $route->get('{repo}/commits/{commitishPath}', function ($repo, $commitishPath) use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+            $route->get('{repo}/commits/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
-            if ($commitishPath === null) {
-                $commitishPath = $repository->getHead();
-            }
+                if ($commitishPath === null) {
+                    $commitishPath = $repository->getHead();
+                }
 
-            list($branch, $file) = $app['util.routing']
-                ->parseCommitishPathParam($commitishPath, $repo);
+                list($branch, $file) = $app['util.routing']
+                    ->parseCommitishPathParam($commitishPath, $repo);
 
-            list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
+                list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
 
-            $type = $file ? "$branch -- \"$file\"" : $branch;
-            $pager = $app['util.view']->getPager($app['request']->get('page'), $repository->getTotalCommits($type));
-            $commits = $repository->getPaginatedCommits($type, $pager['current']);
-            $categorized = array();
+                $type = $file ? "$branch -- \"$file\"" : $branch;
+                $pager = $app['util.view']->getPager($app['request']->get('page'), $repository->getTotalCommits($type));
+                $commits = $repository->getPaginatedCommits($type, $pager['current']);
+                $categorized = array();
 
-            foreach ($commits as $commit) {
-                $date = $commit->getCommiterDate();
-                $date = $date->format('Y-m-d');
-                $categorized[$date][] = $commit;
-            }
+                foreach ($commits as $commit) {
+                    $date = $commit->getCommiterDate();
+                    $date = $date->format('Y-m-d');
+                    $categorized[$date][] = $commit;
+                }
 
-            $template = $app['request']->isXmlHttpRequest() ? 'commits_list.twig' : 'commits.twig';
+                $template = $app['request']->isXmlHttpRequest() ? 'commits_list.twig' : 'commits.twig';
 
-            return $app['twig']->render($template, array(
-                'page'           => 'commits',
-                'pager'          => $pager,
-                'repo'           => $repo,
-                'branch'         => $branch,
-                'branches'       => $repository->getBranches(),
-                'tags'           => $repository->getTags(),
-                'commits'        => $categorized,
-                'file'           => $file,
-            ));
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
-          ->value('commitishPath', null)
-          ->convert('commitishPath', 'escaper.argument:escape')
-          ->bind('commits');
+                return $app['twig']->render($template, array(
+                    'page'           => 'commits',
+                    'pager'          => $pager,
+                    'repo'           => $repo,
+                    'branch'         => $branch,
+                    'branches'       => $repository->getBranches(),
+                    'tags'           => $repository->getTags(),
+                    'commits'        => $categorized,
+                    'file'           => $file,
+                ));
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
+              ->value('commitishPath', null)
+              ->convert('commitishPath', 'escaper.argument:escape')
+              ->bind('commits');
 
-        $route->post('{repo}/commits/{branch}/search', function (Request $request, $repo, $branch = '') use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
-            $query = $request->get('query');
+            $route->post('{repo}/commits/{branch}/search', function (Request $request, $repo, $branch = '') use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+                $query = $request->get('query');
 
-            $commits = $repository->searchCommitLog($query, $branch);
-            $categorized = array();
+                $commits = $repository->searchCommitLog($query, $branch);
+                $categorized = array();
 
-            foreach ($commits as $commit) {
-                $date = $commit->getCommiterDate();
-                $date = $date->format('Y-m-d');
-                $categorized[$date][] = $commit;
-            }
+                foreach ($commits as $commit) {
+                    $date = $commit->getCommiterDate();
+                    $date = $date->format('Y-m-d');
+                    $categorized[$date][] = $commit;
+                }
 
-            return $app['twig']->render('searchcommits.twig', array(
-                'repo'           => $repo,
-                'branch'         => $branch,
-                'file'           => '',
-                'commits'        => $categorized,
-                'branches'       => $repository->getBranches(),
-                'tags'           => $repository->getTags(),
-                'query'          => $query
-            ));
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('branch', $app['util.routing']->getBranchRegex())
-          ->convert('branch', 'escaper.argument:escape')
-          ->bind('searchcommits');
+                return $app['twig']->render('searchcommits.twig', array(
+                    'repo'           => $repo,
+                    'branch'         => $branch,
+                    'file'           => '',
+                    'commits'        => $categorized,
+                    'branches'       => $repository->getBranches(),
+                    'tags'           => $repository->getTags(),
+                    'query'          => $query
+                ));
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('branch', $app['util.routing']->getBranchRegex())
+              ->convert('branch', 'escaper.argument:escape')
+              ->bind('searchcommits');
 
-        $route->get('{repo}/commit/{commit}', function ($repo, $commit) use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
-            $commit = $repository->getCommit($commit);
-            $branch = $repository->getHead();
+            $route->get('{repo}/commit/{commit}', function ($repo, $commit) use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+                $commit = $repository->getCommit($commit);
+                $branch = $repository->getHead();
 
-            return $app['twig']->render('commit.twig', array(
-                'branch'         => $branch,
-                'repo'           => $repo,
-                'commit'         => $commit,
-            ));
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('commit', '[a-f0-9^]+')
-          ->bind('commit');
+                return $app['twig']->render('commit.twig', array(
+                    'branch'         => $branch,
+                    'repo'           => $repo,
+                    'commit'         => $commit,
+                ));
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('commit', '[a-f0-9^]+')
+              ->bind('commit');
 
-        $route->get('{repo}/blame/{commitishPath}', function ($repo, $commitishPath) use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+            $route->get('{repo}/blame/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
-            list($branch, $file) = $app['util.routing']
-                ->parseCommitishPathParam($commitishPath, $repo);
+                list($branch, $file) = $app['util.routing']
+                    ->parseCommitishPathParam($commitishPath, $repo);
 
-            list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
+                list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
 
-            $blames = $repository->getBlame("$branch -- \"$file\"");
+                $blames = $repository->getBlame("$branch -- \"$file\"");
 
-            return $app['twig']->render('blame.twig', array(
-                'file'           => $file,
-                'repo'           => $repo,
-                'branch'         => $branch,
-                'branches'       => $repository->getBranches(),
-                'tags'           => $repository->getTags(),
-                'blames'         => $blames,
-            ));
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
-          ->convert('commitishPath', 'escaper.argument:escape')
-          ->bind('blame');
+                return $app['twig']->render('blame.twig', array(
+                    'file'           => $file,
+                    'repo'           => $repo,
+                    'branch'         => $branch,
+                    'branches'       => $repository->getBranches(),
+                    'tags'           => $repository->getTags(),
+                    'blames'         => $blames,
+                ));
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
+              ->convert('commitishPath', 'escaper.argument:escape')
+              ->bind('blame');
+        } catch(NoRepositoryException $e) {
+        }
 
         return $route;
     }

--- a/src/Controller/NetworkController.php
+++ b/src/Controller/NetworkController.php
@@ -7,6 +7,7 @@ use Gitter\Model\Commit\Commit;
 use Silex\Application;
 use Silex\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use GitList\Exception\NoRepositoryException;
 
 class NetworkController implements ControllerProviderInterface
 {
@@ -14,112 +15,115 @@ class NetworkController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get('{repo}/network/{commitishPath}/{page}.json',
-            function ($repo, $commitishPath, $page) use ($app) {
-                /** @var $repository Repository */
-                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+        try {
+            $route->get('{repo}/network/{commitishPath}/{page}.json',
+                function ($repo, $commitishPath, $page) use ($app) {
+                    /** @var $repository Repository */
+                    $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
-                if ($commitishPath === null) {
-                    $commitishPath = $repository->getHead();
-                }
+                    if ($commitishPath === null) {
+                        $commitishPath = $repository->getHead();
+                    }
 
-                $pager = $app['util.view']->getPager($page, $repository->getTotalCommits($commitishPath));
-                $commits = $repository->getPaginatedCommits($commitishPath, $pager['current']);
+                    $pager = $app['util.view']->getPager($page, $repository->getTotalCommits($commitishPath));
+                    $commits = $repository->getPaginatedCommits($commitishPath, $pager['current']);
 
-                $jsonFormattedCommits = array();
+                    $jsonFormattedCommits = array();
 
-                foreach ($commits as $commit) {
-                    $detailsUrl = $app['url_generator']->generate(
-                        'commit',
-                        array(
-                            'repo' => $repo,
-                            'commit' => $commit->getHash()
-                        )
-                    );
-
-                    $jsonFormattedCommits[$commit->getHash()] = array(
-                        'hash' => $commit->getHash(),
-                        'parentsHash' => $commit->getParentsHash(),
-                        'date' => $commit->getDate()->format('U'),
-                        'message' => htmlentities($commit->getMessage()),
-                        'details' => $detailsUrl,
-                        'author' => array(
-                            'name' => $commit->getAuthor()->getName(),
-                            'email' => $commit->getAuthor()->getEmail(),
-                            'image' => $app->getAvatar($commit->getAuthor()->getEmail(), 40)
-                        )
-                    );
-                }
-
-                $nextPageUrl = null;
-
-                if ($pager['last'] !== $pager['current']) {
-                    $nextPageUrl = $app['url_generator']->generate(
-                        'networkData',
-                        array(
-                            'repo' => $repo,
-                            'commitishPath' => $commitishPath,
-                            'page' => $pager['next']
-                        )
-                    );
-                }
-
-                // when no commits are given, return an empty response - issue #369
-                if (count($commits) === 0) {
-                    return $app->json(
-                        array(
-                            'repo' => $repo,
-                            'commitishPath' => $commitishPath,
-                            'nextPage' => null,
-                            'start' => null,
-                            'commits' => $jsonFormattedCommits
-                            ), 200
+                    foreach ($commits as $commit) {
+                        $detailsUrl = $app['url_generator']->generate(
+                            'commit',
+                            array(
+                                'repo' => $repo,
+                                'commit' => $commit->getHash()
+                            )
                         );
-                }
 
-                return $app->json( array(
-                    'repo' => $repo,
-                    'commitishPath' => $commitishPath,
-                    'nextPage' => $nextPageUrl,
-                    'start' => $commits[0]->getHash(),
-                    'commits' => $jsonFormattedCommits
-                    ), 200
-                );
-            }
-        )->assert('repo', $app['util.routing']->getRepositoryRegex())
-        ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
-        ->value('commitishPath', null)
-        ->convert('commitishPath', 'escaper.argument:escape')
-        ->assert('page', '\d+')
-        ->value('page', '0')
-        ->bind('networkData');
+                        $jsonFormattedCommits[$commit->getHash()] = array(
+                            'hash' => $commit->getHash(),
+                            'parentsHash' => $commit->getParentsHash(),
+                            'date' => $commit->getDate()->format('U'),
+                            'message' => htmlentities($commit->getMessage()),
+                            'details' => $detailsUrl,
+                            'author' => array(
+                                'name' => $commit->getAuthor()->getName(),
+                                'email' => $commit->getAuthor()->getEmail(),
+                                'image' => $app->getAvatar($commit->getAuthor()->getEmail(), 40)
+                            )
+                        );
+                    }
 
-        $route->get(
-            '{repo}/network/{commitishPath}',
-            function ($repo, $commitishPath) use ($app) {
-                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+                    $nextPageUrl = null;
 
-                if ($commitishPath === null) {
-                    $commitishPath = $repository->getHead();
-                }
+                    if ($pager['last'] !== $pager['current']) {
+                        $nextPageUrl = $app['url_generator']->generate(
+                            'networkData',
+                            array(
+                                'repo' => $repo,
+                                'commitishPath' => $commitishPath,
+                                'page' => $pager['next']
+                            )
+                        );
+                    }
 
-                list($branch, $file) = $app['util.routing']->parseCommitishPathParam($commitishPath, $repo);
-                list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
+                    // when no commits are given, return an empty response - issue #369
+                    if (count($commits) === 0) {
+                        return $app->json(
+                            array(
+                                'repo' => $repo,
+                                'commitishPath' => $commitishPath,
+                                'nextPage' => null,
+                                'start' => null,
+                                'commits' => $jsonFormattedCommits
+                                ), 200
+                            );
+                    }
 
-                return $app['twig']->render(
-                    'network.twig',
-                    array(
+                    return $app->json( array(
                         'repo' => $repo,
-                        'branch' => $branch,
                         'commitishPath' => $commitishPath,
-                    )
-                );
-            }
-        )->assert('repo', $app['util.routing']->getRepositoryRegex())
-        ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
-        ->value('commitishPath', null)
-        ->convert('commitishPath', 'escaper.argument:escape')
-        ->bind('network');
+                        'nextPage' => $nextPageUrl,
+                        'start' => $commits[0]->getHash(),
+                        'commits' => $jsonFormattedCommits
+                        ), 200
+                    );
+                }
+            )->assert('repo', $app['util.routing']->getRepositoryRegex())
+            ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
+            ->value('commitishPath', null)
+            ->convert('commitishPath', 'escaper.argument:escape')
+            ->assert('page', '\d+')
+            ->value('page', '0')
+            ->bind('networkData');
+
+            $route->get(
+                '{repo}/network/{commitishPath}',
+                function ($repo, $commitishPath) use ($app) {
+                    $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+
+                    if ($commitishPath === null) {
+                        $commitishPath = $repository->getHead();
+                    }
+
+                    list($branch, $file) = $app['util.routing']->parseCommitishPathParam($commitishPath, $repo);
+                    list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
+
+                    return $app['twig']->render(
+                        'network.twig',
+                        array(
+                            'repo' => $repo,
+                            'branch' => $branch,
+                            'commitishPath' => $commitishPath,
+                        )
+                    );
+                }
+            )->assert('repo', $app['util.routing']->getRepositoryRegex())
+            ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
+            ->value('commitishPath', null)
+            ->convert('commitishPath', 'escaper.argument:escape')
+            ->bind('network');
+        } catch(NoRepositoryException $e) {
+        }
 
         return $route;
     }

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -6,6 +6,7 @@ use Silex\Application;
 use Silex\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use GitList\Exception\NoRepositoryException;
 
 class TreeController implements ControllerProviderInterface
 {
@@ -13,115 +14,118 @@ class TreeController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get('{repo}/tree/{commitishPath}/', $treeController = function ($repo, $commitishPath = '') use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
-            if (!$commitishPath) {
-                $commitishPath = $repository->getHead();
-            }
+        try {
+            $route->get('{repo}/tree/{commitishPath}/', $treeController = function ($repo, $commitishPath = '') use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+                if (!$commitishPath) {
+                    $commitishPath = $repository->getHead();
+                }
 
-            list($branch, $tree) = $app['util.routing']->parseCommitishPathParam($commitishPath, $repo);
+                list($branch, $tree) = $app['util.routing']->parseCommitishPathParam($commitishPath, $repo);
 
-            list($branch, $tree) = $app['util.repository']->extractRef($repository, $branch, $tree);
-            $files = $repository->getTree($tree ? "$branch:\"$tree\"/" : $branch);
-            $breadcrumbs = $app['util.view']->getBreadcrumbs($tree);
+                list($branch, $tree) = $app['util.repository']->extractRef($repository, $branch, $tree);
+                $files = $repository->getTree($tree ? "$branch:\"$tree\"/" : $branch);
+                $breadcrumbs = $app['util.view']->getBreadcrumbs($tree);
 
-            $parent = null;
-            if (($slash = strrpos($tree, '/')) !== false) {
-                $parent = substr($tree, 0, $slash);
-            } elseif (!empty($tree)) {
-                $parent = '';
-            }
+                $parent = null;
+                if (($slash = strrpos($tree, '/')) !== false) {
+                    $parent = substr($tree, 0, $slash);
+                } elseif (!empty($tree)) {
+                    $parent = '';
+                }
 
-            return $app['twig']->render('tree.twig', array(
-                'files'          => $files->output(),
-                'repo'           => $repo,
-                'branch'         => $branch,
-                'path'           => $tree ? $tree . '/' : $tree,
-                'parent'         => $parent,
-                'breadcrumbs'    => $breadcrumbs,
-                'branches'       => $repository->getBranches(),
-                'tags'           => $repository->getTags(),
-                'readme'         => $app['util.repository']->getReadme($repository, $branch, $tree ? "$tree" : ""),
-            ));
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
-          ->convert('commitishPath', 'escaper.argument:escape')
-          ->bind('tree');
+                return $app['twig']->render('tree.twig', array(
+                    'files'          => $files->output(),
+                    'repo'           => $repo,
+                    'branch'         => $branch,
+                    'path'           => $tree ? $tree . '/' : $tree,
+                    'parent'         => $parent,
+                    'breadcrumbs'    => $breadcrumbs,
+                    'branches'       => $repository->getBranches(),
+                    'tags'           => $repository->getTags(),
+                    'readme'         => $app['util.repository']->getReadme($repository, $branch, $tree ? "$tree" : ""),
+                ));
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
+              ->convert('commitishPath', 'escaper.argument:escape')
+              ->bind('tree');
 
-        $route->post('{repo}/tree/{branch}/search', function (Request $request, $repo, $branch = '', $tree = '') use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
-            if (!$branch) {
-                $branch = $repository->getHead();
-            }
+            $route->post('{repo}/tree/{branch}/search', function (Request $request, $repo, $branch = '', $tree = '') use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+                if (!$branch) {
+                    $branch = $repository->getHead();
+                }
 
-            $query = $request->get('query');
-            $breadcrumbs = array(array('dir' => 'Search results for: ' . $query, 'path' => ''));
-            $results = $repository->searchTree($query, $branch);
+                $query = $request->get('query');
+                $breadcrumbs = array(array('dir' => 'Search results for: ' . $query, 'path' => ''));
+                $results = $repository->searchTree($query, $branch);
 
-            return $app['twig']->render('search.twig', array(
-                'results'        => $results,
-                'repo'           => $repo,
-                'branch'         => $branch,
-                'path'           => $tree,
-                'breadcrumbs'    => $breadcrumbs,
-                'branches'       => $repository->getBranches(),
-                'tags'           => $repository->getTags(),
-                'query'          => $query
-            ));
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('branch', $app['util.routing']->getBranchRegex())
-          ->convert('branch', 'escaper.argument:escape')
-          ->bind('search');
+                return $app['twig']->render('search.twig', array(
+                    'results'        => $results,
+                    'repo'           => $repo,
+                    'branch'         => $branch,
+                    'path'           => $tree,
+                    'breadcrumbs'    => $breadcrumbs,
+                    'branches'       => $repository->getBranches(),
+                    'tags'           => $repository->getTags(),
+                    'query'          => $query
+                ));
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('branch', $app['util.routing']->getBranchRegex())
+              ->convert('branch', 'escaper.argument:escape')
+              ->bind('search');
 
-        $route->get('{repo}/{format}ball/{branch}', function($repo, $format, $branch) use ($app) {
-            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+            $route->get('{repo}/{format}ball/{branch}', function($repo, $format, $branch) use ($app) {
+                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
-            $tree = $repository->getBranchTree($branch);
+                $tree = $repository->getBranchTree($branch);
 
-            if (false === $tree) {
-                return $app->abort(404, 'Invalid commit or tree reference: ' . $branch);
-            }
+                if (false === $tree) {
+                    return $app->abort(404, 'Invalid commit or tree reference: ' . $branch);
+                }
 
-            $file = $app['cache.archives'] . DIRECTORY_SEPARATOR
-                    . $repo . DIRECTORY_SEPARATOR
-                    . substr($tree, 0, 2) . DIRECTORY_SEPARATOR
-                    . substr($tree, 2)
-                    . '.'
-                    . $format;
+                $file = $app['cache.archives'] . DIRECTORY_SEPARATOR
+                        . $repo . DIRECTORY_SEPARATOR
+                        . substr($tree, 0, 2) . DIRECTORY_SEPARATOR
+                        . substr($tree, 2)
+                        . '.'
+                        . $format;
 
-            if (!file_exists($file)) {
-                $repository->createArchive($tree, $file, $format);
-            }
+                if (!file_exists($file)) {
+                    $repository->createArchive($tree, $file, $format);
+                }
 
-            /**
-             * Generating name for downloading, lowercasing and removing all non
-             * ascii and special characters
-             */
-            $filename = strtolower($repo.'_'.$branch);
-            $filename = preg_replace('#[^a-z0-9]+#', '_', $filename);
-            $filename = $filename . '.' . $format;
+                /**
+                 * Generating name for downloading, lowercasing and removing all non
+                 * ascii and special characters
+                 */
+                $filename = strtolower($repo.'_'.$branch);
+                $filename = preg_replace('#[^a-z0-9]+#', '_', $filename);
+                $filename = $filename . '.' . $format;
 
-            $response = new BinaryFileResponse($file);
-            $response->setContentDisposition('attachment', $filename);
-            return $response;
-        })->assert('format', '(zip|tar)')
-          ->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('branch', $app['util.routing']->getBranchRegex())
-          ->convert('branch', 'escaper.argument:escape')
-          ->bind('archive');
+                $response = new BinaryFileResponse($file);
+                $response->setContentDisposition('attachment', $filename);
+                return $response;
+            })->assert('format', '(zip|tar)')
+              ->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('branch', $app['util.routing']->getBranchRegex())
+              ->convert('branch', 'escaper.argument:escape')
+              ->bind('archive');
 
 
-        $route->get('{repo}/{branch}/', function($repo, $branch) use ($app, $treeController) {
-            return $treeController($repo, $branch);
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('branch', $app['util.routing']->getBranchRegex())
-          ->convert('branch', 'escaper.argument:escape')
-          ->bind('branch');
+            $route->get('{repo}/{branch}/', function($repo, $branch) use ($app, $treeController) {
+                return $treeController($repo, $branch);
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->assert('branch', $app['util.routing']->getBranchRegex())
+              ->convert('branch', 'escaper.argument:escape')
+              ->bind('branch');
 
-        $route->get('{repo}/', function($repo) use ($app, $treeController) {
-            return $treeController($repo);
-        })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->bind('repository');
+            $route->get('{repo}/', function($repo) use ($app, $treeController) {
+                return $treeController($repo);
+            })->assert('repo', $app['util.routing']->getRepositoryRegex())
+              ->bind('repository');
+        } catch(NoRepositoryException $e) {
+        }
 
         return $route;
     }

--- a/src/Controller/TreeGraphController.php
+++ b/src/Controller/TreeGraphController.php
@@ -5,6 +5,7 @@ namespace GitList\Controller;
 use Silex\Application;
 use Silex\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use GitList\Exception\NoRepositoryException;
 
 class TreeGraphController implements ControllerProviderInterface
 {
@@ -12,61 +13,64 @@ class TreeGraphController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get(
-            '{repo}/treegraph/{commitishPath}',
-            function ($repo, $commitishPath) use ($app) {
-                /** @var \GitList\Git\Repository $repository */
-                $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+        try {
+            $route->get(
+                '{repo}/treegraph/{commitishPath}',
+                function ($repo, $commitishPath) use ($app) {
+                    /** @var \GitList\Git\Repository $repository */
+                    $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
-                $command = 'log --graph --date-order --all -C -M -n 100 --date=iso ' .
-                    '--pretty=format:"B[%d] C[%H] D[%ad] A[%an] E[%ae] H[%h] S[%s]"';
-                $rawRows = $repository->getClient()->run($repository, $command);
-                $rawRows = explode("\n", $rawRows);
-                $graphItems = array();
+                    $command = 'log --graph --date-order --all -C -M -n 100 --date=iso ' .
+                        '--pretty=format:"B[%d] C[%H] D[%ad] A[%an] E[%ae] H[%h] S[%s]"';
+                    $rawRows = $repository->getClient()->run($repository, $command);
+                    $rawRows = explode("\n", $rawRows);
+                    $graphItems = array();
 
-                foreach ($rawRows as $row) {
-                    if (preg_match("/^(.+?)(\s(B\[(.*?)\])? C\[(.+?)\] D\[(.+?)\] A\[(.+?)\] E\[(.+?)\] H\[(.+?)\] S\[(.+?)\])?$/", $row, $output)) {
-                        if (!isset($output[4])) {
+                    foreach ($rawRows as $row) {
+                        if (preg_match("/^(.+?)(\s(B\[(.*?)\])? C\[(.+?)\] D\[(.+?)\] A\[(.+?)\] E\[(.+?)\] H\[(.+?)\] S\[(.+?)\])?$/", $row, $output)) {
+                            if (!isset($output[4])) {
+                                $graphItems[] = array(
+                                    "relation"=>$output[1]
+                                );
+                                continue;
+                            }
                             $graphItems[] = array(
-                                "relation"=>$output[1]
+                                "relation"=>$output[1],
+                                "branch"=>$output[4],
+                                "rev"=>$output[5],
+                                "date"=>$output[6],
+                                "author"=>$output[7],
+                                "author_email"=>$output[8],
+                                "short_rev"=>$output[9],
+                                "subject"=>preg_replace('/(^|\s)(#[[:xdigit:]]+)(\s|$)/', '$1<a href="$2">$2</a>$3', $output[10])
                             );
-                            continue;
                         }
-                        $graphItems[] = array(
-                            "relation"=>$output[1],
-                            "branch"=>$output[4],
-                            "rev"=>$output[5],
-                            "date"=>$output[6],
-                            "author"=>$output[7],
-                            "author_email"=>$output[8],
-                            "short_rev"=>$output[9],
-                            "subject"=>preg_replace('/(^|\s)(#[[:xdigit:]]+)(\s|$)/', '$1<a href="$2">$2</a>$3', $output[10])
-                        );
                     }
+
+                    if ($commitishPath === null) {
+                        $commitishPath = $repository->getHead();
+                    }
+
+                    list($branch, $file) = $app['util.routing']->parseCommitishPathParam($commitishPath, $repo);
+                    list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
+
+                    return $app['twig']->render(
+                        'treegraph.twig',
+                        array(
+                            'repo' => $repo,
+                            'branch' => $branch,
+                            'commitishPath' => $commitishPath,
+                            'graphItems' => $graphItems,
+                        )
+                    );
                 }
-
-                if ($commitishPath === null) {
-                    $commitishPath = $repository->getHead();
-                }
-
-                list($branch, $file) = $app['util.routing']->parseCommitishPathParam($commitishPath, $repo);
-                list($branch, $file) = $app['util.repository']->extractRef($repository, $branch, $file);
-
-                return $app['twig']->render(
-                    'treegraph.twig',
-                    array(
-                        'repo' => $repo,
-                        'branch' => $branch,
-                        'commitishPath' => $commitishPath,
-                        'graphItems' => $graphItems,
-                    )
-                );
-            }
-        )->assert('repo', $app['util.routing']->getRepositoryRegex())
-            ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
-            ->value('commitishPath', null)
-            ->convert('commitishPath', 'escaper.argument:escape')
-            ->bind('treegraph');
+            )->assert('repo', $app['util.routing']->getRepositoryRegex())
+                ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
+                ->value('commitishPath', null)
+                ->convert('commitishPath', 'escaper.argument:escape')
+                ->bind('treegraph');
+        } catch(NoRepositoryException $e) {
+        }
 
         return $route;
     }

--- a/src/Exception/NoRepositoryException.php
+++ b/src/Exception/NoRepositoryException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GitList\Exception;
+
+class NoRepositoryException extends \RuntimeException
+{
+
+}

--- a/src/Git/Client.php
+++ b/src/Git/Client.php
@@ -58,8 +58,18 @@ class Client extends BaseClient
         return $allRepositories;
     }
 
-    private function recurseDirectory($path, $topLevel = true)
+    private function recurseDirectory($path, $topLevel = true, $basePath = "")
     {
+        if ($topLevel) {
+            if(mb_substr($path, -1) !== DIRECTORY_SEPARATOR) {
+                $path .= DIRECTORY_SEPARATOR;
+            }
+
+            $basePath = $path;
+        }
+
+        $relativePath = preg_replace("/^" . preg_quote($basePath, "/") . "/", "", $path);
+
         $dir = new \DirectoryIterator($path);
 
         $repositories = array();
@@ -99,7 +109,7 @@ class Client extends BaseClient
                     }
 
                     if (!$topLevel) {
-                        $repoName = $file->getPathInfo()->getFilename() . '/' . $file->getFilename();
+                        $repoName = $relativePath . "/" . $file->getFilename();
                     } else {
                         $repoName = $file->getFilename();
                     }
@@ -116,7 +126,7 @@ class Client extends BaseClient
 
                     continue;
                 } else {
-                    $repositories = array_merge($repositories, $this->recurseDirectory($file->getPathname(), false));
+                    $repositories = array_merge($repositories, $this->recurseDirectory($file->getPathname(), false, $basePath));
                 }
             }
         }

--- a/src/Git/GitoliteClient.php
+++ b/src/Git/GitoliteClient.php
@@ -33,12 +33,7 @@ class GitoliteClient extends BaseClient
         }
 
         $path = $paths[0];
-        $cmd = $this->gitoliteWrapperPath ."  '". $this->username ."'";
-        $output = shell_exec($cmd);
-
-        if($output) {
-            $output = json_decode($output, true);
-        }
+        $output = $this->getGitoliteData();
 
         if($output) {
             if(!isset($output['repos'])) {
@@ -66,6 +61,24 @@ class GitoliteClient extends BaseClient
         }
 
         return $allRepositories;
+    }
+
+    protected function getGitoliteData()
+    {
+        $cmd = $this->gitoliteWrapperPath ."  '". $this->username ."'";
+        $output = shell_exec($cmd);
+
+        if(!$output) {
+            return false;
+        }
+
+        $output = json_decode($output, true);
+
+        if(!$output) {
+            return false;
+        }
+
+        return $output;
     }
 }
 

--- a/src/Git/GitoliteClient.php
+++ b/src/Git/GitoliteClient.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace GitList\Git;
+
+use GitList\Git\Client as BaseClient;
+use GitList\Exception\NoRepositoryException;
+
+class GitoliteClient extends BaseClient
+{
+    protected $gitoliteWrapperPath;
+    protected $username;
+
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+        $this->gitoliteWrapperPath = $options['gitolite.wrapper_path'];
+        $this->username = $options['username'];
+    }
+
+    /**
+     * Filter accessible repositories for a user.
+     *
+     * @param  array $paths Array of paths where repositories will be searched
+     * @return array Found repositories, containing their name, path and description sorted
+     *               by repository name
+     */
+    public function getRepositories($paths)
+    {
+        $allRepositories = parent::getRepositories($paths);
+
+        if(sizeof($paths) !== 1) {
+            throw new \RuntimeException('Gitolite requires only one root repo directory.');
+        }
+
+        $path = $paths[0];
+        $cmd = $this->gitoliteWrapperPath ."  '". $this->username ."'";
+        $output = shell_exec($cmd);
+
+        if($output) {
+            $output = json_decode($output, true);
+        }
+
+        if($output) {
+            if(!isset($output['repos'])) {
+                $allRepositories = array();
+            }
+
+            foreach($allRepositories as $repository => $options) {
+                if(mb_substr($path, -1) !== DIRECTORY_SEPARATOR) {
+                    $path .= DIRECTORY_SEPARATOR;
+                }
+
+                $repositoryName = preg_replace('/^' . preg_quote($path, '/') . '/', '', $options['path']);
+                $repositoryName = preg_replace('/\.git$/', '', $repositoryName);
+
+                if(!isset($output['repos'][$repositoryName]) || !isset($output['repos'][$repositoryName]['perms']['R']) || $output['repos'][$repositoryName]['perms']['R'] !== 1) {
+                    unset($allRepositories[$repository]);
+                }
+            }
+        } else {
+            throw new \RuntimeException('There is a problem getting repo info.');
+        }
+
+        if (empty($allRepositories)) {
+            throw new NoRepositoryException('No repository is accessible to you.');
+        }
+
+        return $allRepositories;
+    }
+}
+

--- a/src/Git/GitoliteClient.php
+++ b/src/Git/GitoliteClient.php
@@ -65,7 +65,7 @@ class GitoliteClient extends BaseClient
 
     protected function getGitoliteData()
     {
-        $cmd = $this->gitoliteWrapperPath ."  '". $this->username ."'";
+        $cmd = $this->gitoliteWrapperPath ."  ". escapeshellarg($this->username);
         $output = shell_exec($cmd);
 
         if(!$output) {

--- a/src/Provider/GitServiceProvider.php
+++ b/src/Provider/GitServiceProvider.php
@@ -3,6 +3,7 @@
 namespace GitList\Provider;
 
 use GitList\Git\Client;
+use GitList\Git\GitoliteClient;
 use Silex\Application;
 use Silex\ServiceProviderInterface;
 
@@ -23,6 +24,13 @@ class GitServiceProvider implements ServiceProviderInterface
             $options['projects'] = $app['git.projects'];
             $options['ini.file'] = $app['ini.file'];
             $options['default_branch'] = $app['git.default_branch'];
+
+            if($app['gitolite.active']) {
+                $options['gitolite.wrapper_path'] = $app['gitolite.wrapper_path'];
+                $options['username'] = $app['username'];
+
+                return new GitoliteClient($options);
+            }
 
             return new Client($options);
         };


### PR DESCRIPTION
This pull request allows integration with Gitolite. It contains a fix for full relative path of nested repositories (based on #536 with my comments) which is critical for this. Since there is a chance that a user doesn't have access to any repository, I added catching `NoRepositoryException` to all Controllers so a user sees nice error message (not `RuntimeException` or a blank page).

~~To get list of accessible repos you have to write 2 simple scripts (see below). The first one gitolite-wrapper.sh is called from GitList itself and it calls the second one gitolite-perms.sh via sudo as gitolite user (so the web server user doesn't have ability to call gitolite command via sudo).~~

I included scripts in this PR.

**Requirements**
- You have to setup a web server to perform authentification and pass username in `$_SERVER['PHP_AUTH_USER']`.
- Usernames must correspond to those in gitolite.
- You have to allow web server user to call `gitolite-perms.sh` via sudo as gitolite user and permit passing env variable `GL_USER`.

I hope this helps.
