### PR TITLE
Fixes incompatible method definition of GitList\Git\Repository::getHead().

### DIFF
--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -27,7 +27,7 @@ class Repository extends BaseRepository
     /**
      * Get the current branch, returning a default value when HEAD is detached.
      */
-    public function getHead()
+    public function getHead($default = NULL)
     {
         $client = $this->getClient();
 


### PR DESCRIPTION
This PR fixes strict standards warning: _Declaration of GitList\Git\Repository::getHead() should be compatible with that of Gitter\Repository::getHead() in /home/travis/build/klaussilveira/gitlist/src/Git/Repository.php on line 12_.

This was mentioned in #692 and was fixed #676 (which was closed without merging).
