### PR TITLE
Add the option to view patch log for individual files

### DIFF
--- a/src/Controller/BlobController.php
+++ b/src/Controller/BlobController.php
@@ -70,6 +70,26 @@ class BlobController implements ControllerProviderInterface
           ->convert('commitishPath', 'escaper.argument:escape')
           ->bind('blob_raw');
 
+        $route->get('{repo}/logpatch/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+            $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
+
+            list($branch, $file) = $app['util.routing']
+                ->parseCommitishPathParam($commitishPath, $repo);
+
+            $filePatchesLog = $repository->getCommitsLogPatch($file);
+            $breadcrumbs = $app['util.view']->getBreadcrumbs($file);
+
+            return $app['twig']->render('logpatch.twig', array(
+                'branch'         => $branch,
+                'repo'           => $repo,
+                'breadcrumbs'    => $breadcrumbs,
+                'commits'        => $filePatchesLog,
+            ));
+        })->assert('repo', $app['util.routing']->getRepositoryRegex())
+            ->assert('commitishPath', '.+')
+            ->convert('commitishPath', 'escaper.argument:escape')
+            ->bind('logpatch');
+
         return $route;
     }
 }

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -54,7 +54,7 @@ class Repository extends BaseRepository
             . "</item>\" $file"
         );
 
-        $patch_collection = [];
+        $patch_collection = array();
         foreach ( preg_split('/('.$record_delimiter.'\<item\>)/', $file_patches,null, PREG_SPLIT_NO_EMPTY) as $patches) {
             $patches = '<item>' . $patches;
             $xmlEnd = strpos($patches, '</item>') + 7;

--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -35,6 +35,46 @@ class Repository extends BaseRepository
     }
 
     /**
+     * Show Patches that where apllied to the selected file
+     *
+     * @param  string $file File path for which we will retrieve a list of patch logs
+     * @return array  Collection of Commits data
+     */
+    public function getCommitsLogPatch($file)
+    {
+        $record_delimiter = chr(hexdec("0x1e"));
+        $file_patches = $this->getClient()->run($this,
+            "log -p --pretty=format:\"".$record_delimiter."<item><hash>%H</hash>"
+            . "<short_hash>%h</short_hash><tree>%T</tree><parents>%P</parents>"
+            . "<author>%aN</author><author_email>%aE</author_email>"
+            . "<date>%at</date><commiter>%cN</commiter><commiter_email>%cE</commiter_email>"
+            . "<commiter_date>%ct</commiter_date>"
+            . "<message><![CDATA[%s]]></message>"
+            . "<body><![CDATA[%b]]></body>"
+            . "</item>\" $file"
+        );
+
+        $patch_collection = [];
+        foreach ( preg_split('/('.$record_delimiter.'\<item\>)/', $file_patches,null, PREG_SPLIT_NO_EMPTY) as $patches) {
+            $patches = '<item>' . $patches;
+            $xmlEnd = strpos($patches, '</item>') + 7;
+            $commitInfo = substr($patches, 0, $xmlEnd);
+            $commitData = substr($patches, $xmlEnd);
+            $logs = explode("\n", $commitData);
+
+            // Read commit metadata
+            $format = new PrettyFormat;
+            $data = $format->parse($commitInfo);
+            $commit = new Commit;
+            $commit->importData($data[0]);
+            $commit->setDiffs($this->readDiffLogs($logs));
+            $patch_collection[] = $commit;
+        }
+
+        return $patch_collection;
+    }
+
+    /**
      * Show the data from a specific commit
      *
      * @param  string $commitHash Hash of the specific commit to read data

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -225,8 +225,10 @@ class InterfaceTest extends WebTestCase
                 $crawler->filter('.source-header .btn-group a')->eq(0)->attr('href'));
         $this->assertEquals('/GitTest/blame/master/test.php',
                 $crawler->filter('.source-header .btn-group a')->eq(1)->attr('href'));
+        $this->assertEquals('/GitTest/logpatch/master/test.php',
+                $crawler->filter('.source-header .btn-group a')->eq(2)->attr('href'));        
         $this->assertEquals('/GitTest/commits/master/test.php',
-                $crawler->filter('.source-header .btn-group a')->eq(2)->attr('href'));
+                $crawler->filter('.source-header .btn-group a')->eq(3)->attr('href'));
     }
 
     /**
@@ -307,6 +309,25 @@ class InterfaceTest extends WebTestCase
         $this->assertEquals('mailto:darth@empire.com', $crawler->filter('.table tbody tr td span a')->eq(1)->attr('href'));
     }
 
+
+    public function testPatchLogPage()
+    {
+        $client = $this->createClient();
+
+        $crawler = $client->request('GET', '/GitTest/logpatch/master/test.php');
+        $this->assertTrue($client->getResponse()->isOk());
+        $this->assertEquals('Initial commit', $crawler->filter('.commit-header h4')->eq(0)->text());
+
+        $crawler = $client->request('GET', '/GitTest/logpatch/master/README.md');
+        $this->assertTrue($client->getResponse()->isOk());
+        $this->assertEquals('Initial commit', $crawler->filter('.commit-header h4')->eq(0)->text());
+
+        $crawler = $client->request('GET', '/foobar/logpatch/master/bar.json');
+        $this->assertTrue($client->getResponse()->isOk());
+        $this->assertEquals('First commit', $crawler->filter('.commit-header h4')->eq(0)->text());
+    }
+
+    
     /**
      * @covers GitList\Controller\MainController::connect
      */

--- a/themes/bootstrap3/twig/file.twig
+++ b/themes/bootstrap3/twig/file.twig
@@ -14,6 +14,7 @@
             <div class="btn-group pull-right">
                 <a href="{{ path('blob_raw', {repo: repo, commitishPath: branch ~ '/' ~ file}) }}" class="btn btn-default btn-sm"><span class="fa fa-file-text-o"></span> Raw</a>
                 <a href="{{ path('blame', {repo: repo, commitishPath: branch ~ '/' ~ file}) }}" class="btn btn-default btn-sm"><span class="fa fa-bullhorn"></span> Blame</a>
+                <a href="{{ path('logpatch', {repo: repo, commitishPath: branch ~ '/' ~ file}) }}" class="btn btn-default btn-sm"><span class="fa fa-calendar"></span> Patch Log</a>
                 <a href="{{ path('commits', {repo: repo, commitishPath: branch ~ '/' ~ file}) }}" class="btn btn-default btn-sm"><span class="fa fa-list"></span> History</a>
             </div>
         </div>

--- a/themes/bootstrap3/twig/logpatch.twig
+++ b/themes/bootstrap3/twig/logpatch.twig
@@ -1,0 +1,84 @@
+{% extends 'layout_page.twig' %}
+
+{% set page = 'Log Patches' %}
+
+{% block title %}GitList{% endblock %}
+
+{% block content %}
+
+    {% include 'breadcrumb.twig' with {breadcrumbs: breadcrumbs} %}
+    
+    {% for commit in commits %}
+        
+        <div class="commit-view">
+            <div class="commit-header">
+            <span class="pull-right">
+                <a class="btn btn-default btn-sm" href="{{ path('branch', {repo: repo, branch: commit.hash}) }}" title="Browse code at this point in history"><span class="fa fa-list-alt"></span> Browse code</a></span>
+                <h4>{{ commit.message }}</h4>
+            </div>
+            <div class="commit-body">
+                {% if commit.body is not empty %}
+                    <p>{{ commit.body | nl2br }}</p>
+                {% endif %}
+                <img src="{{ avatar(commit.author.email, 32) }}" class="pull-left space-right" />
+                <span>
+                <a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}
+                    {% if commit.author.email != commit.commiter.email %}
+                        &bull; <a href="mailto:{{ commit.commiter.email }}">{{ commit.commiter.name }}</a> committed on {{ commit.commiterDate | format_date }}
+                    {% endif %}
+                    <br />Showing {{ commit.changedFiles }} changed files
+            </span>
+            </div>
+        </div>
+
+        {% for diff in commit.diffs %}
+            <div class="source-view">
+                <div class="source-header">
+                    <div class="meta"><a id="diff-{{ loop.index }}">{{ diff.file }}</div>
+
+                    <div class="btn-group pull-right">
+                        <a href="{{ path('commits', {repo: repo, commitishPath: commit.hash ~ '/' ~ diff.file}) }}"  class="btn btn-default btn-sm"><span class="fa fa-list-alt"></span> History</a>
+                        <a href="{{ path('blob', {repo: repo, commitishPath: commit.hash ~'/' ~ diff.file}) }}"  class="btn btn-default btn-sm"><span class="fa fa-file"></span> View file @ {{ commit.shortHash }}</a>
+                    </div>
+                </div>
+
+                <div class="source-diff">
+                    <table>
+                        {% for line in diff.getLines %}
+                            <tr>
+                                <td class="lineNo">
+                                    {% if line.getType != 'chunk' %}
+                                    <a name="L{{ loop.index }}R{{ line.getNumOld }}"></a>
+                                    <a href="#L{{ loop.index }}R{{ line.getNumOld }}">
+                                        {% endif %}
+                                        {{ line.getNumOld }}
+                                        {% if line.getType != 'chunk' %}
+                                    </a>
+                                    {% endif %}
+                                </td>
+                                <td class="lineNo">
+                                    {% if line.getType != 'chunk' %}
+                                    <a name="L{{ loop.index }}L{{ line.getNumNew }}"></a>
+                                    <a href="#L{{ loop.index }}L{{ line.getNumNew }}">
+                                        {% endif %}
+                                        {{ line.getNumNew }}
+                                        {% if line.getType != 'chunk' %}
+                                    </a>
+                                    {% endif %}
+                                </td>
+                                <td style="width: 100%">
+                                    <pre{% if line.getType %} class="{{ line.getType }}"{% endif %}>{{ line.getLine }}</pre>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            </div>
+        {% endfor %}
+
+    {% endfor %}
+
+    
+
+    <hr />
+{% endblock %}

--- a/themes/default/twig/file.twig
+++ b/themes/default/twig/file.twig
@@ -14,6 +14,7 @@
             <div class="btn-group pull-right">
                 <a href="{{ path('blob_raw', {repo: repo, commitishPath: branch ~ '/' ~ file}) }}" class="btn btn-small"><i class="icon-file"></i> Raw</a>
                 <a href="{{ path('blame', {repo: repo, commitishPath: branch ~ '/' ~ file}) }}" class="btn btn-small"><i class="icon-bullhorn"></i> Blame</a>
+                <a href="{{ path('logpatch', {repo: repo, commitishPath: branch ~ '/' ~ file}) }}" class="btn btn-small"><i class="icon-calendar"></i> Patch Log</a>
                 <a href="{{ path('commits', {repo: repo, commitishPath: branch ~ '/' ~ file}) }}" class="btn btn-small"><i class="icon-list-alt"></i> History</a>
             </div>
         </div>

--- a/themes/default/twig/logpatch.twig
+++ b/themes/default/twig/logpatch.twig
@@ -1,0 +1,83 @@
+{% extends 'layout_page.twig' %}
+
+{% set page = 'commits' %}
+
+{% block title %}GitList{% endblock %}
+
+{% block content %}
+    
+    {% include 'breadcrumb.twig' with {breadcrumbs: breadcrumbs} %}
+    
+    {% for commit in commits %}
+
+        <div class="commit-view">
+            <div class="commit-header">
+                <span class="pull-right"><a class="btn btn-small" href="{{ path('branch', {repo: repo, branch: commit.hash}) }}" title="Browse code at this point in history"><i class="icon-list-alt"></i> Browse code</a></span>
+                <h4>{{ commit.message }}</h4>
+            </div>
+            <div class="commit-body">
+                {% if commit.body is not empty %}
+                    <p>{{ commit.body | nl2br }}</p>
+                {% endif %}
+                <img src="{{ avatar(commit.author.email, 32) }}" class="pull-left space-right" />
+                <span>
+                <a href="mailto:{{ commit.author.email }}">{{ commit.author.name }}</a> authored on {{ commit.date | format_date }}
+                    {% if commit.author.email != commit.commiter.email %}
+                        &bull; <a href="mailto:{{ commit.commiter.email }}">{{ commit.commiter.name }}</a> committed on {{ commit.commiterDate | format_date }}
+                    {% endif %}
+                    <br />Showing {{ commit.changedFiles }} changed files
+            </span>
+            </div>
+        </div>
+
+        {% for diff in commit.diffs %}
+            <div class="source-view">
+                <div class="source-header">
+                    <div class="meta"><a id="diff-{{ loop.index }}">{{ diff.file }}</div>
+
+                    <div class="btn-group pull-right">
+                        <a href="{{ path('commits', {repo: repo, commitishPath: commit.hash ~ '/' ~ diff.file}) }}" class="btn btn-small"><i class="icon-list-alt"></i> History</a>
+                        <a href="{{ path('blob', {repo: repo, commitishPath: commit.hash ~'/' ~ diff.file}) }}" class="btn btn-small"><i class="icon-file"></i> View file @ {{ commit.shortHash }}</a>
+                    </div>
+                </div>
+
+                <div class="source-diff">
+                    <table>
+                        {% for line in diff.getLines %}
+                            <tr>
+                                <td class="lineNo">
+                                    {% if line.getType != 'chunk' %}
+                                    <a name="L{{ loop.index }}R{{ line.getNumOld }}"></a>
+                                    <a href="#L{{ loop.index }}R{{ line.getNumOld }}">
+                                        {% endif %}
+                                        {{ line.getNumOld }}
+                                        {% if line.getType != 'chunk' %}
+                                    </a>
+                                    {% endif %}
+                                </td>
+                                <td class="lineNo">
+                                    {% if line.getType != 'chunk' %}
+                                    <a name="L{{ loop.index }}L{{ line.getNumNew }}"></a>
+                                    <a href="#L{{ loop.index }}L{{ line.getNumNew }}">
+                                        {% endif %}
+                                        {{ line.getNumNew }}
+                                        {% if line.getType != 'chunk' %}
+                                    </a>
+                                    {% endif %}
+                                </td>
+                                <td style="width: 100%">
+                                    <pre{% if line.getType %} class="{{ line.getType }}"{% endif %}>{{ line.getLine }}</pre>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </table>
+                </div>
+            </div>
+        {% endfor %}
+        
+    {% endfor %}
+
+
+
+    <hr />
+{% endblock %}


### PR DESCRIPTION
Very usefull to see all the commits that changed a specific file and what changes were made (diffs)
cli: git log -p /path/file
![img_patchlog](https://cloud.githubusercontent.com/assets/3596864/20242435/6d57d638-a936-11e6-9216-62f7d4bee4ff.png)
