### PR TITLE
Update .htaccess for apache > 2.3

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -9,6 +9,15 @@
     RewriteRule ^(.*)$ index.php/$1 [L,NC]
 </IfModule>
 <Files config.ini>
-    order allow,deny
-    deny from all
+    # Apache < 2.3
+    <IfModule !mod_authz_core.c>
+        Order allow,deny
+        Deny from all
+        Satisfy All
+    </IfModule>
+
+    # Apache ≥ 2.3
+    <IfModule mod_authz_core.c>
+        Require all denied
+    </IfModule>
 </Files>


### PR DESCRIPTION
Using "Deny from all" throws a server error if not using mod_access_compat (Module for 2.2 compatibility).
Using "require" instead of "deny" is encouraged by apache, see https://httpd.apache.org/docs/2.4/upgrading.html

By using <IfModule> as a switch, compatibility with apache 2.2 is kept intact.

Fixes #733 (and probably others)