### PR TITLE
Automatic RewriteBase, so that we don't have to update the ".htaccess" file

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -2,11 +2,16 @@
     Options -MultiViews +SymLinksIfOwnerMatch
 
     RewriteEngine On
-    #RewriteBase /path/to/gitlist/
+
+    RewriteCond %{ENV:URI} ^$
+    RewriteRule ^(.*)$ - [ENV=URI:$1]
+
+    RewriteCond %{ENV:BASE} ^$
+    RewriteCond %{ENV:URI}::%{REQUEST_URI} ^(.*)::(.*?)\1$
+    RewriteRule ^ - [ENV=BASE:%2]
 
     RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule ^(.*)$ index.php/$1 [L,NC]
+    RewriteRule ^(.*)$ %{ENV:BASE}index.php [L,QSA]
 </IfModule>
 <Files config.ini>
     order allow,deny

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ In order to run GitList on your server, you'll need:
 * Do not download a branch or tag from GitHub, unless you want to use the development version. The version available for download at the website already has all dependencies bundled, so you don't have to use composer or any other tool
 * Rename the `config.ini-example` file to `config.ini`.
 * Open up the `config.ini` and configure your installation. You'll have to provide where your repositories are located.
-* In case GitList isn't accessed through the root of the website, open .htaccess and edit RewriteBase (for example, /gitlist/ if GitList is accessed through http://localhost/gitlist/).
 * Create the cache folder and give read/write permissions to your web server user:
 
 ```


### PR DESCRIPTION
We need to update the ".htaccess" file in case GitList isn't accessed through the root of the website, or if we later moved an existing GitList installation to another directory.

The solution is based on the following StackOverflow QA:
https://stackoverflow.com/questions/21027343/let-htaccess-rewriterule-redirect-to-a-script-in-current-dir-instead-of-an-e/

Initially this seems like a bit of magic, but if you read all explanations at the StackOverflow QA, including the comments, the code starts to make sense.

I've tested this thoroughly and it works OK with my Apache 2.4 installations.