### PR TITLE
Fixed #775: Stylesheet include paths and CSP MIME types.

### DIFF
--- a/themes/bootstrap3/twig/layout.twig
+++ b/themes/bootstrap3/twig/layout.twig
@@ -4,28 +4,28 @@
         <meta charset="UTF-8" />
         <title>{% block title %}Welcome!{% endblock %}</title>
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <link rel="stylesheet" type="text/css" href="{{ global.request.basepath }}/themes/{{ theme }}/css/style.css">
-        <link rel="stylesheet" type="text/css" href="{{ global.request.basepath }}/themes/{{ theme }}/css/fontawesome.css">
-        <link rel="stylesheet" type="text/css" href="{{ global.request.basepath }}/themes/{{ theme }}/css/gitgraph.css">
-        <link rel="shortcut icon" type="image/png" href="{{ global.request.basepath }}/themes/{{ theme }}/img/favicon.png" />
+        <link rel="stylesheet" type="text/css" href="{{ app.request.basepath }}/themes/{{ theme }}/css/style.css">
+        <link rel="stylesheet" type="text/css" href="{{ app.request.basepath }}/themes/{{ theme }}/css/fontawesome.css">
+        <link rel="stylesheet" type="text/css" href="{{ app.request.basepath }}/themes/{{ theme }}/css/gitgraph.css">
+        <link rel="shortcut icon" type="image/png" href="{{ app.request.basepath }}/themes/{{ theme }}/img/favicon.png" />
         <!--[if lt IE 9]>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/html5.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/html5.js"></script>
         <![endif]-->
     </head>
 
     <body>
         {% block body %}{% endblock %}
         {% block javascripts %}
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/jquery.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/raphael.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/bootstrap.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/codemirror.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/showdown.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/table.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/main.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/networkGraph.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/gitgraph.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/draw.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/jquery.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/raphael.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/bootstrap.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/codemirror.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/showdown.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/table.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/main.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/networkGraph.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/gitgraph.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/draw.js"></script>
         {% endblock %}
     </body>
 </html>

--- a/themes/default/twig/layout.twig
+++ b/themes/default/twig/layout.twig
@@ -3,28 +3,28 @@
     <head>
         <meta charset="UTF-8" />
         <title>{{ title }}{% if title %} - {% endif %}{% block title %}Welcome!{% endblock %}</title>
-        <link rel="stylesheet" type="text/css" href="{{ global.request.basepath }}/themes/{{ theme }}/css/style.css">
-        <link rel="stylesheet" type="text/css" href="{{ global.request.basepath }}/themes/{{ theme }}/css/gitgraph.css">
-        <link rel="shortcut icon" type="image/png" href="{{ global.request.basepath }}/themes/{{ theme }}/img/favicon.png" />
+        <link rel="stylesheet" type="text/css" href="{{ app.request.basepath }}/themes/{{ theme }}/css/style.css">
+        <link rel="stylesheet" type="text/css" href="{{ app.request.basepath }}/themes/{{ theme }}/css/gitgraph.css">
+        <link rel="shortcut icon" type="image/png" href="{{ app.request.basepath }}/themes/{{ theme }}/img/favicon.png" />
         <!--[if lt IE 9]>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/html5.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/html5.js"></script>
         <![endif]-->
     </head>
 
     <body>
         {% block body %}{% endblock %}
         {% block javascripts %}
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/jquery.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/raphael.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/bootstrap.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/codemirror.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/showdown.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/table.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/list.min.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/main.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/networkGraph.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/gitgraph.js"></script>
-        <script src="{{ global.request.basepath }}/themes/{{ theme }}/js/draw.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/jquery.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/raphael.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/bootstrap.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/codemirror.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/showdown.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/table.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/list.min.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/main.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/networkGraph.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/gitgraph.js"></script>
+        <script type="application/javascript" src="{{ app.request.basepath }}/themes/{{ theme }}/js/draw.js"></script>
         {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
Changed `global.request.basepath` back to `app.request.basepath` and added some MIME types (`application/javascript`, `text/javascript` is obsoleted).