### PR TITLE
Support relative links in Markdown

### DIFF
--- a/config.ini-example
+++ b/config.ini-example
@@ -56,3 +56,7 @@ http_user_dynamic = false ; when enabled, http_user is set to $_SERVER['PHP_AUTH
 [avatar]
 ; url = '//gravatar.com/avatar/'
 ; query[] = 'd=identicon'
+
+; rendering options
+[render]
+; deep_readme = true

--- a/src/Application.php
+++ b/src/Application.php
@@ -31,13 +31,14 @@ class Application extends SilexApplication
         $this->path = realpath($root);
 
         $this['debug'] = $config->get('app', 'debug');
-        $this['theme'] = $config->get('app', 'theme') ? $config->get('app', 'theme') : 'default';
-        $this['date.format'] = $config->get('date', 'format') ? $config->get('date', 'format') : 'd/m/Y H:i:s';
+        $this['theme'] = $config->get('app', 'theme', 'default');
+        $this['date.format'] = $config->get('date', 'format', 'd/m/Y H:i:s');
         $this['filetypes'] = $config->getSection('filetypes');
         $this['binary_filetypes'] = $config->getSection('binary_filetypes');
         $this['cache.archives'] = $this->getCachePath() . 'archives';
         $this['avatar.url'] = $config->get('avatar', 'url');
         $this['avatar.query'] = $config->get('avatar', 'query');
+        $this['render.deep_readme'] = $config->get('render', 'deep_readme', true);
 
         // Register services
         $this->register(new TwigServiceProvider(), array(
@@ -55,10 +56,8 @@ class Application extends SilexApplication
             'git.client' => $config->get('git', 'client'),
             'git.repos' => $repositories,
             'ini.file' => 'config.ini',
-            'git.hidden' => $config->get('git', 'hidden') ?
-                                    $config->get('git', 'hidden') : array(),
-            'git.default_branch' => $config->get('git', 'default_branch') ?
-                                    $config->get('git', 'default_branch') : 'master',
+            'git.hidden' => $config->get('git', 'hidden', array()),
+            'git.default_branch' => $config->get('git', 'default_branch', 'master')
         ));
 
         $this->register(new ViewUtilServiceProvider());
@@ -73,7 +72,7 @@ class Application extends SilexApplication
             $twig->addFilter(new \Twig_SimpleFilter('format_size', array($app, 'formatSize')));
             $twig->addFunction(new \Twig_SimpleFunction('avatar', array($app, 'getAvatar')));
             $twig->addGlobal('theme', $app['theme']);
-            $twig->addGlobal('title', $config->get('app', 'title') ? $config->get('app', 'title') : 'GitList');
+            $twig->addGlobal('title', $config->get('app', 'title', 'GitList'));
             $twig->addGlobal('show_http_remote', $config->get('clone_button', 'show_http_remote'));
             $twig->addGlobal('use_https', $config->get('clone_button', 'use_https'));
             $twig->addGlobal('http_url_subdir', $config->get('clone_button', 'http_url_subdir'));

--- a/src/Config.php
+++ b/src/Config.php
@@ -24,14 +24,14 @@ class Config
         return $config;
     }
 
-    public function get($section, $option)
+    public function get($section, $option, $default = false)
     {
         if (!array_key_exists($section, $this->data)) {
-            return false;
+            return $default;
         }
 
         if (!array_key_exists($option, $this->data[$section])) {
-            return false;
+            return $default;
         }
 
         return $this->data[$section][$option];

--- a/src/Controller/BlobController.php
+++ b/src/Controller/BlobController.php
@@ -12,7 +12,7 @@ class BlobController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get('{repo}/blob/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+        $route->get('show/{repo}/{commitishPath}', function ($repo, $commitishPath) use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
             list($branch, $file) = $app['util.routing']
@@ -42,11 +42,11 @@ class BlobController implements ControllerProviderInterface
                 'tags' => $repository->getTags(),
             ));
         })->assert('repo', $app['util.routing']->getRepositoryRegex())
-          ->assert('commitishPath', '.+')
+          ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
           ->convert('commitishPath', 'escaper.argument:escape')
           ->bind('blob');
 
-        $route->get('{repo}/raw/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+        $route->get('raw/{repo}/{commitishPath}', function ($repo, $commitishPath) use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
             list($branch, $file) = $app['util.routing']
@@ -70,7 +70,7 @@ class BlobController implements ControllerProviderInterface
           ->convert('commitishPath', 'escaper.argument:escape')
           ->bind('blob_raw');
 
-        $route->get('{repo}/logpatch/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+        $route->get('logpatch/{repo}/{commitishPath}', function ($repo, $commitishPath) use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
             list($branch, $file) = $app['util.routing']
@@ -86,7 +86,7 @@ class BlobController implements ControllerProviderInterface
                 'commits' => $filePatchesLog,
             ));
         })->assert('repo', $app['util.routing']->getRepositoryRegex())
-            ->assert('commitishPath', '.+')
+            ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())
             ->convert('commitishPath', 'escaper.argument:escape')
             ->bind('logpatch');
 

--- a/src/Controller/CommitController.php
+++ b/src/Controller/CommitController.php
@@ -12,9 +12,9 @@ class CommitController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get('{repo}/commits/search', function (Request $request, $repo) use ($app) {
+        $route->get('searchcommits/{repo}', function (Request $request, $repo) use ($app) {
             $subRequest = Request::create(
-                '/' . $repo . '/commits/master/search',
+                '/' . $repo . '/searchcommits/' . $app['git.default_branch'],
                 'POST',
                 array('query' => $request->get('query'))
             );
@@ -22,7 +22,7 @@ class CommitController implements ControllerProviderInterface
             return $app->handle($subRequest, \Symfony\Component\HttpKernel\HttpKernelInterface::SUB_REQUEST);
         })->assert('repo', $app['util.routing']->getRepositoryRegex());
 
-        $route->get('{repo}/commits/{commitishPath}', function (Request $request, $repo, $commitishPath) use ($app) {
+        $route->get('commits/{repo}/{commitishPath}', function (Request $request, $repo, $commitishPath) use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
             if ($commitishPath === null) {
@@ -63,7 +63,7 @@ class CommitController implements ControllerProviderInterface
           ->convert('commitishPath', 'escaper.argument:escape')
           ->bind('commits');
 
-        $route->post('{repo}/commits/{branch}/search', function (Request $request, $repo, $branch = '') use ($app) {
+        $route->post('searchcommits/{repo}/{branch}', function (Request $request, $repo, $branch = '') use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
             $query = $request->get('query');
 
@@ -90,7 +90,7 @@ class CommitController implements ControllerProviderInterface
           ->convert('branch', 'escaper.argument:escape')
           ->bind('searchcommits');
 
-        $route->get('{repo}/commit/{commit}', function ($repo, $commit) use ($app) {
+        $route->get('commit/{repo}/{commit}', function ($repo, $commit) use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
             $commit = $repository->getCommit($commit);
             $branch = $repository->getHead();
@@ -104,7 +104,7 @@ class CommitController implements ControllerProviderInterface
           ->assert('commit', '[a-f0-9^]+')
           ->bind('commit');
 
-        $route->get('{repo}/blame/{commitishPath}', function ($repo, $commitishPath) use ($app) {
+        $route->get('blame/{repo}/{commitishPath}', function ($repo, $commitishPath) use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
             list($branch, $file) = $app['util.routing']

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -13,7 +13,7 @@ class TreeController implements ControllerProviderInterface
     {
         $route = $app['controllers_factory'];
 
-        $route->get('{repo}/tree/{commitishPath}/', $treeController = function ($repo, $commitishPath = '') use ($app) {
+        $route->get('show/{repo}/{commitishPath}/', $treeController = function ($repo, $commitishPath = '') use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
             if (!$commitishPath) {
                 $commitishPath = $repository->getHead();
@@ -48,7 +48,7 @@ class TreeController implements ControllerProviderInterface
           ->convert('commitishPath', 'escaper.argument:escape')
           ->bind('tree');
 
-        $route->post('{repo}/tree/{branch}/search', function (Request $request, $repo, $branch = '', $tree = '') use ($app) {
+        $route->post('search/{repo}/{branch}/', function (Request $request, $repo, $branch = '', $tree = '') use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
             if (!$branch) {
                 $branch = $repository->getHead();
@@ -73,7 +73,7 @@ class TreeController implements ControllerProviderInterface
           ->convert('branch', 'escaper.argument:escape')
           ->bind('search');
 
-        $route->get('{repo}/{format}ball/{branch}', function ($repo, $format, $branch) use ($app) {
+        $route->get('{format}ball/{repo}/{branch}', function ($format, $repo, $branch) use ($app) {
             $repository = $app['git']->getRepositoryFromName($app['git.repos'], $repo);
 
             $tree = $repository->getBranchTree($branch);
@@ -111,15 +111,18 @@ class TreeController implements ControllerProviderInterface
           ->convert('branch', 'escaper.argument:escape')
           ->bind('archive');
 
-        $route->get('{repo}/{branch}/', function ($repo, $branch) use ($app, $treeController) {
+        $route->get('show/{repo}/{branch}/', function ($repo, $branch) use ($app, $treeController) {
             return $treeController($repo, $branch);
         })->assert('repo', $app['util.routing']->getRepositoryRegex())
           ->assert('branch', $app['util.routing']->getBranchRegex())
           ->convert('branch', 'escaper.argument:escape')
           ->bind('branch');
 
-        $route->get('{repo}/', function ($repo) use ($app, $treeController) {
-            return $treeController($repo);
+        $route->get('show/{repo}/', function ($repo) use ($app) {
+            return $app->redirect($app['url_generator']->generate('tree', array(
+                'repo' => $repo,
+                'commitishPath' => $app['git.default_branch'],
+            )));
         })->assert('repo', $app['util.routing']->getRepositoryRegex())
           ->bind('repository');
 

--- a/src/Controller/TreeController.php
+++ b/src/Controller/TreeController.php
@@ -41,7 +41,7 @@ class TreeController implements ControllerProviderInterface
                 'breadcrumbs' => $breadcrumbs,
                 'branches' => $repository->getBranches(),
                 'tags' => $repository->getTags(),
-                'readme' => $app['util.repository']->getReadme($repository, $branch, $tree ? "$tree" : ''),
+                'readme' => $app['util.repository']->getReadme($app, $repository, $branch, $tree ? "$tree" : ''),
             ));
         })->assert('repo', $app['util.routing']->getRepositoryRegex())
           ->assert('commitishPath', $app['util.routing']->getCommitishPathRegex())

--- a/src/Util/Repository.php
+++ b/src/Util/Repository.php
@@ -165,7 +165,7 @@ class Repository
         return false;
     }
 
-    public function getReadme($repository, $branch = null, $path = '')
+    public function getReadme($app, $repository, $branch = null, $path = '')
     {
         if ($branch === null) {
             $branch = $repository->getHead();
@@ -186,8 +186,8 @@ class Repository
             }
         }
         // No contextual readme, try to catch the main one if we are in deeper context
-        if ($path != '') {
-            return $this->getReadme($repository, $branch, '');
+        if ($path != '' && $app['render.deep_readme']) {
+            return $this->getReadme($app, $repository, $branch, '');
         }
 
         return array();

--- a/src/Util/Routing.php
+++ b/src/Util/Routing.php
@@ -109,17 +109,6 @@ class Routing
         return $commitishPathRegex;
     }
 
-    public function getPathRegex()
-    {
-        static $pathRegex = null;
-
-        if ($pathRegex === null) {
-            $pathRegex = '.+';
-        }
-
-        return $pathRegex;
-    }
-
     public function getRepositoryRegex()
     {
         static $regex = null;

--- a/src/Util/Routing.php
+++ b/src/Util/Routing.php
@@ -103,10 +103,21 @@ class Routing
         static $commitishPathRegex = null;
 
         if ($commitishPathRegex === null) {
-            $commitishPathRegex = '.+';
+            $commitishPathRegex = '.*[^/]';
         }
 
         return $commitishPathRegex;
+    }
+
+    public function getPathRegex()
+    {
+        static $pathRegex = null;
+
+        if ($pathRegex === null) {
+            $pathRegex = '.+';
+        }
+
+        return $pathRegex;
     }
 
     public function getRepositoryRegex()

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -163,28 +163,28 @@ class InterfaceTest extends WebTestCase
         $this->assertCount(1, $crawler->filter('title:contains("GitList")'));
 
         $this->assertCount(1, $crawler->filter('div.repository-header a:contains("detached-head")'));
-        $this->assertEquals('/detached-head/', $crawler->filter('.repository-header a')->eq(0)->attr('href'));
+        $this->assertEquals('/show/detached-head/', $crawler->filter('.repository-header a')->eq(0)->attr('href'));
         $this->assertEquals('/detached-head/master/rss/', $crawler->filter('.repository-header a')->eq(1)->attr('href'));
 
         $this->assertCount(1, $crawler->filter('div.repository-header a:contains("develop")'));
-        $this->assertEquals('/develop/', $crawler->filter('.repository-header a')->eq(2)->attr('href'));
+        $this->assertEquals('/show/develop/', $crawler->filter('.repository-header a')->eq(2)->attr('href'));
         $this->assertEquals('/develop/master/rss/', $crawler->filter('.repository-header a')->eq(3)->attr('href'));
 
         $this->assertCount(1, $crawler->filter('div.repository-header:contains("foobar")'));
         $this->assertCount(1, $crawler->filter('div.repository-body:contains("This is a test repo!")'));
-        $this->assertEquals('/foobar/', $crawler->filter('.repository-header a')->eq(4)->attr('href'));
+        $this->assertEquals('/show/foobar/', $crawler->filter('.repository-header a')->eq(4)->attr('href'));
         $this->assertEquals('/foobar/master/rss/', $crawler->filter('.repository-header a')->eq(5)->attr('href'));
 
         $this->assertCount(1, $crawler->filter('div.repository-header a:contains("GitTest")'));
-        $this->assertEquals('/GitTest/', $crawler->filter('.repository-header a')->eq(6)->attr('href'));
+        $this->assertEquals('/show/GitTest/', $crawler->filter('.repository-header a')->eq(6)->attr('href'));
         $this->assertEquals('/GitTest/master/rss/', $crawler->filter('.repository-header a')->eq(7)->attr('href'));
 
         $this->assertCount(1, $crawler->filter('div.repository-header a:contains("mailmap")'));
-        $this->assertEquals('/mailmap/', $crawler->filter('.repository-header a')->eq(8)->attr('href'));
+        $this->assertEquals('/show/mailmap/', $crawler->filter('.repository-header a')->eq(8)->attr('href'));
         $this->assertEquals('/mailmap/master/rss/', $crawler->filter('.repository-header a')->eq(9)->attr('href'));
 
         $this->assertCount(1, $crawler->filter('div.repository-header a:contains("nested/NestedRepo")'));
-        $this->assertEquals('/nested/NestedRepo/', $crawler->filter('.repository-header a')->eq(10)->attr('href'));
+        $this->assertEquals('/show/nested/NestedRepo/', $crawler->filter('.repository-header a')->eq(10)->attr('href'));
         $this->assertEquals('/nested/NestedRepo/master/rss/', $crawler->filter('.repository-header a')->eq(11)->attr('href'));
         $this->assertCount(1, $crawler->filter('div.repository-body:contains("This is a NESTED test repo!")'));
     }
@@ -196,28 +196,34 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/GitTest/');
+        $client->request('GET', '/show/GitTest/');
+        $this->assertTrue($client->getResponse()->isRedirect());
+
+        $crawler = $client->request('GET', $client->getResponse()->headers->get('location'));
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertCount(1, $crawler->filter('.tree tr:contains("README.md")'));
         $this->assertCount(1, $crawler->filter('.tree tr:contains("test.php")'));
         $this->assertCount(1, $crawler->filter('.md-header:contains("README.md")'));
         $this->assertEquals("## GitTest\nGitTest is a *test* repository!", $crawler->filter('#md-content')->eq(0)->text());
-        $this->assertEquals('/GitTest/blob/master/README.md', $crawler->filter('.tree tr td')->eq(0)->filter('a')->eq(0)->attr('href'));
-        $this->assertEquals('/GitTest/blob/master/test.php', $crawler->filter('.tree tr td')->eq(3)->filter('a')->eq(0)->attr('href'));
+        $this->assertEquals('/show/GitTest/master/README.md', $crawler->filter('.tree tr td')->eq(0)->filter('a')->eq(0)->attr('href'));
+        $this->assertEquals('/show/GitTest/master/test.php', $crawler->filter('.tree tr td')->eq(3)->filter('a')->eq(0)->attr('href'));
 
         $this->assertEquals('branch/name/wiith/slashes', $crawler->filter('.dropdown-menu li')->eq(1)->text());
         $this->assertEquals('issue12', $crawler->filter('.dropdown-menu li')->eq(2)->text());
         $this->assertEquals('issue42', $crawler->filter('.dropdown-menu li')->eq(3)->text());
         $this->assertEquals('master', $crawler->filter('.dropdown-menu li')->eq(4)->text());
 
-        $crawler = $client->request('GET', '/foobar/');
+        $client->request('GET', '/show/foobar/');
+        $this->assertTrue($client->getResponse()->isRedirect());
+
+        $crawler = $client->request('GET', $client->getResponse()->headers->get('location'));
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertCount(1, $crawler->filter('.tree tr:contains("myfolder")'));
         $this->assertCount(1, $crawler->filter('.tree tr:contains("testfolder")'));
         $this->assertCount(1, $crawler->filter('.tree tr:contains("bar.json")'));
-        $this->assertEquals('/foobar/tree/master/myfolder/', $crawler->filter('.tree tr td')->eq(0)->filter('a')->eq(0)->attr('href'));
-        $this->assertEquals('/foobar/tree/master/testfolder/', $crawler->filter('.tree tr td')->eq(3)->filter('a')->eq(0)->attr('href'));
-        $this->assertEquals('/foobar/blob/master/bar.json', $crawler->filter('.tree tr td')->eq(6)->filter('a')->eq(0)->attr('href'));
+        $this->assertEquals('/show/foobar/master/myfolder/', $crawler->filter('.tree tr td')->eq(0)->filter('a')->eq(0)->attr('href'));
+        $this->assertEquals('/show/foobar/master/testfolder/', $crawler->filter('.tree tr td')->eq(3)->filter('a')->eq(0)->attr('href'));
+        $this->assertEquals('/show/foobar/master/bar.json', $crawler->filter('.tree tr td')->eq(6)->filter('a')->eq(0)->attr('href'));
         $this->assertCount(0, $crawler->filter('.md-header'));
         $this->assertEquals('master', $crawler->filter('.dropdown-menu li')->eq(1)->text());
     }
@@ -229,24 +235,24 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/GitTest/blob/master/test.php');
+        $crawler = $client->request('GET', '/show/GitTest/master/test.php');
 
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertCount(1, $crawler->filter('.breadcrumb .active:contains("test.php")'));
         $this->assertEquals(
-            '/GitTest/raw/master/test.php',
+            '/raw/GitTest/master/test.php',
                 $crawler->filter('.source-header .btn-group a')->eq(0)->attr('href')
         );
         $this->assertEquals(
-            '/GitTest/blame/master/test.php',
+            '/blame/GitTest/master/test.php',
                 $crawler->filter('.source-header .btn-group a')->eq(1)->attr('href')
         );
         $this->assertEquals(
-            '/GitTest/logpatch/master/test.php',
+            '/logpatch/GitTest/master/test.php',
                 $crawler->filter('.source-header .btn-group a')->eq(2)->attr('href')
         );
         $this->assertEquals(
-            '/GitTest/commits/master/test.php',
+            '/commits/GitTest/master/test.php',
                 $crawler->filter('.source-header .btn-group a')->eq(3)->attr('href')
         );
     }
@@ -258,7 +264,7 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/GitTest/raw/master/test.php');
+        $crawler = $client->request('GET', '/raw/GitTest/master/test.php');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals("<?php\necho 'Hello World'; // This is a test", $client->getResponse()->getContent());
     }
@@ -270,19 +276,19 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/GitTest/blame/master/test.php');
+        $crawler = $client->request('GET', '/blame/GitTest/master/test.php');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertCount(1, $crawler->filter('.source-header .meta:contains("test.php")'));
         $this->assertRegexp(
-            '/\/GitTest\/commit\/[a-zA-Z0-9%]+/',
+            '/\/commit\/GitTest\/[a-zA-Z0-9%]+/',
                 $crawler->filter('.blame-view .commit')->eq(0)->filter('a')->attr('href')
         );
 
-        $crawler = $client->request('GET', '/foobar/blame/master/bar.json');
+        $crawler = $client->request('GET', '/blame/foobar/master/bar.json');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertCount(1, $crawler->filter('.source-header .meta:contains("bar.json")'));
         $this->assertRegexp(
-            '/\/foobar\/commit\/[a-zA-Z0-9%]+/',
+            '/\/commit\/foobar\/[a-zA-Z0-9%]+/',
                 $crawler->filter('.blame-view .commit')->eq(0)->filter('a')->attr('href')
         );
     }
@@ -294,19 +300,19 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/GitTest/commits/master/test.php');
+        $crawler = $client->request('GET', '/commits/GitTest/master/test.php');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('Initial commit', $crawler->filter('.table tbody tr td h4')->eq(0)->text());
 
-        $crawler = $client->request('GET', '/GitTest/commits/master/README.md');
+        $crawler = $client->request('GET', '/commits/GitTest/master/README.md');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('Initial commit', $crawler->filter('.table tbody tr td h4')->eq(0)->text());
 
-        $crawler = $client->request('GET', '/foobar/commits/master/bar.json');
+        $crawler = $client->request('GET', '/commits/foobar/master/bar.json');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('First commit', $crawler->filter('.table tbody tr td h4')->eq(0)->text());
 
-        $crawler = $client->request('GET', '/mailmap/commits/master/README.md');
+        $crawler = $client->request('GET', '/commits/mailmap/master/README.md');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('Anakin Skywalker', $crawler->filter('.table tbody tr td span a')->eq(1)->text());
         $this->assertEquals('mailto:darth@empire.com', $crawler->filter('.table tbody tr td span a')->eq(1)->attr('href'));
@@ -319,15 +325,15 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/GitTest/commits');
+        $crawler = $client->request('GET', '/commits/GitTest');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('Initial commit', $crawler->filter('.table tbody tr td h4')->eq(0)->text());
 
-        $crawler = $client->request('GET', '/foobar/commits');
+        $crawler = $client->request('GET', '/commits/foobar');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('First commit', $crawler->filter('.table tbody tr td h4')->eq(0)->text());
 
-        $crawler = $client->request('GET', '/mailmap/commits');
+        $crawler = $client->request('GET', '/commits/mailmap');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('Anakin Skywalker', $crawler->filter('.table tbody tr td span a')->eq(1)->text());
         $this->assertEquals('mailto:darth@empire.com', $crawler->filter('.table tbody tr td span a')->eq(1)->attr('href'));
@@ -337,15 +343,15 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/GitTest/logpatch/master/test.php');
+        $crawler = $client->request('GET', '/logpatch/GitTest/master/test.php');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('Initial commit', $crawler->filter('.commit-header h4')->eq(0)->text());
 
-        $crawler = $client->request('GET', '/GitTest/logpatch/master/README.md');
+        $crawler = $client->request('GET', '/logpatch/GitTest/master/README.md');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('Initial commit', $crawler->filter('.commit-header h4')->eq(0)->text());
 
-        $crawler = $client->request('GET', '/foobar/logpatch/master/bar.json');
+        $crawler = $client->request('GET', '/logpatch/foobar/master/bar.json');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertEquals('First commit', $crawler->filter('.commit-header h4')->eq(0)->text());
     }
@@ -391,7 +397,11 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $client->request('GET', '/nested/NestedRepo/');
+        $client->request('GET', '/show/nested/NestedRepo/');
+        $response = $client->getResponse();
+
+        $this->assertTrue($response->isRedirect());
+        $client->request('GET', $response->headers->get('location'));
         $response = $client->getResponse();
 
         $this->assertTrue($response->isOk());
@@ -405,7 +415,11 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/develop/');
+        $crawler = $client->request('GET', '/show/develop/');
+
+        $this->assertTrue($client->getResponse()->isRedirect());
+        $client->request('GET', $client->getResponse()->headers->get('location'));
+
         $this->assertTrue($client->getResponse()->isOk());
     }
 
@@ -416,7 +430,7 @@ class InterfaceTest extends WebTestCase
     {
         $client = $this->createClient();
 
-        $crawler = $client->request('GET', '/nested/NestedRepo/testing/');
+        $crawler = $client->request('GET', '/show/nested/NestedRepo/testing/');
         $this->assertTrue($client->getResponse()->isOk());
         $this->assertRegexp('/NESTED TEST BRANCH README/', $client->getResponse()->getContent());
     }

--- a/themes/bootstrap3/twig/layout_page.twig
+++ b/themes/bootstrap3/twig/layout_page.twig
@@ -8,11 +8,11 @@
             <div class="col-sm-12">
             	<div class="tab-border nav-tabs">
                     {% if page in ['commits', 'searchcommits'] %}
-                    <form class="pull-right" action="{{ app.request.basepath }}/{{repo}}/commits/{{branch}}/search" method="POST">
+                    <form class="pull-right" action="{{ app.request.basepath }}/searchcommits/{{repo}}/{{branch}}" method="POST">
                         <input type="search" name="query" class="form-control input-sm" placeholder="Search commits...">
                     </form>
                     {% else %}
-                    <form class="pull-right" action="{{ app.request.basepath }}/{{repo}}/tree/{{branch}}/search" method="POST">
+                    <form class="pull-right" action="{{ app.request.basepath }}/search/{{repo}}/{{branch}}" method="POST">
                         <input type="search" name="query" class="form-control input-sm" placeholder="Search tree...">
                     </form>
                     {% endif %}

--- a/themes/default/twig/layout_page.twig
+++ b/themes/default/twig/layout_page.twig
@@ -7,11 +7,11 @@
         <div class="row">
             <div class="span12">
                 {% if page in ['commits', 'searchcommits'] %}
-                <form class="form-search pull-right" action="{{ app.request.basepath }}/{{repo}}/commits/{{branch}}/search" method="POST">
+                <form class="form-search pull-right" action="{{ app.request.basepath }}/searchcommits/{{repo}}/{{branch}}" method="POST">
                     <input type="text" name="query" class="input-medium search-query" placeholder="Search commits..." value="{{ query | default("") }}">
                 </form>
                 {% else %}
-                <form class="form-search pull-right" action="{{ app.request.basepath }}/{{repo}}/tree/{{branch}}/search" method="POST">
+                <form class="form-search pull-right" action="{{ app.request.basepath }}/search/{{repo}}/{{branch}}/" method="POST">
                     <input type="text" name="query" class="input-medium search-query" placeholder="Search tree..." value="{{ query | default("") }}">
                 </form>
                 {% endif %}


### PR DESCRIPTION
Issues #408 and #659 both show that GitList is not suitable for browsing inter-linked Markdown documents, because relative links between blobs and trees are not possible.

GitHub solved the problem by re-writing all URLs in all rendered HTML to explicitly jump across the /blob/ - /tree/ barrier, instead of altering their URL structure, which would have been utterly disruptive for their users.

In contrast, this pull request solves the problem in the opposite way -- by altering GitList's URL structure to make relative links possible without the need for URL rewriting when rendering Markdown to HTML. As this is a potentially very disruptive change, I do not realistically expect it to be merged into GitList.  I simply present it as a point for discussion of the issue, as evidence of one possible solution.

To fix a secondary issue with relative links in README.md files, this pull request introduces a new `render.deep_readme` config option that can be used to disable the rendering of parent directory README files in sub-directories that lack a README.