### PR TITLE
Fix #391: directory structure is ignored

### DIFF
--- a/src/Git/Client.php
+++ b/src/Git/Client.php
@@ -157,7 +157,7 @@ class Client extends BaseClient
         return $this;
     }
 
-    private function recurseDirectory($path, $topLevel = true)
+    private function recurseDirectory($path, $appendPath = '')
     {
         $dir = new \DirectoryIterator($path);
 
@@ -209,11 +209,7 @@ class Client extends BaseClient
                         $description = null;
                     }
 
-                    if (!$topLevel) {
-                        $repoName = $file->getPathInfo()->getFilename() . '/' . $file->getFilename();
-                    } else {
-                        $repoName = $file->getFilename();
-                    }
+                    $repoName = $appendPath . $file->getFilename();
 
                     if (is_array($this->getProjects()) && !in_array($repoName, $this->getProjects())) {
                         continue;
@@ -227,7 +223,7 @@ class Client extends BaseClient
 
                     continue;
                 }
-                $repositories = array_merge($repositories, $this->recurseDirectory($file->getPathname(), false));
+                $repositories = array_merge($repositories, $this->recurseDirectory($file->getPathname(), $appendPath . $file->getFilename() . '/'));
             }
         }
 


### PR DESCRIPTION
This fixes #391. Instead of only storing whether we are in the top level, we keep the path from the toplevel down to the current directory.

This code is similar to something in #689 (see [this diff](https://github.com/klaussilveira/gitlist/pull/689/files#diff-e5560f8aaae6310420b7f7f0d6f96bf9)).

It is similar to (but neater than) #704.