### PR TITLE
Fix GitList version in the default theme footer

### DIFF
--- a/themes/default/twig/footer.twig
+++ b/themes/default/twig/footer.twig
@@ -1,3 +1,3 @@
 <footer>
-    <p>Powered by <a href="https://github.com/klaussilveira/gitlist">GitList 1.0.0</a></p>
+    <p>Powered by <a href="https://github.com/klaussilveira/gitlist">GitList 1.0.1</a></p>
 </footer>


### PR DESCRIPTION
Hello,

I propose a patch to fix the GitList version in the default theme footer.

Thanks.