### PR TITLE
fix "Patch Log"

### DIFF
--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -54,7 +54,7 @@ class Repository extends BaseRepository
             . '<commiter_date>%ct</commiter_date>'
             . '<message><![CDATA[%s]]></message>'
             . '<body><![CDATA[%b]]></body>'
-            . "</item>\" $file"
+            . "</item>\" -- $file"
         );
 
         $patch_collection = array();


### PR DESCRIPTION
fixes ambiguous argument error when using the "Patch Log" function
```
Oops! fatal: ambiguous argument 'src/CMakeLists.txt': unknown revision or path not in the working tree. Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]' 
```
git version 2.11.0, Debian GNU/Linux 9.5 (stretch)