### PR TITLE
Fixed PHP 7.3 incompatible regular expression

### DIFF
--- a/src/Git/Repository.php
+++ b/src/Git/Repository.php
@@ -339,7 +339,7 @@ class Repository extends BaseRepository
                 continue;
             }
 
-            preg_match_all('/([\w-._]+):([^:]+):([0-9]+):(.+)/', $result, $matches, PREG_SET_ORDER);
+            preg_match_all('/([\w\-._]+):([^:]+):([0-9]+):(.+)/', $result, $matches, PREG_SET_ORDER);
 
             $data['branch'] = $matches[0][1];
             $data['file'] = $matches[0][2];


### PR DESCRIPTION
As of PHP 7.3 a hyphen ("-") in a regular expression needs to be escaped.

For example:
Wrong: `preg_match('/[\w-.]+/', '');`
Correct: `preg_match('/[\w\-.]+/', '');`

This is due to the move from PCRE to PCRE 2 (see https://ayesh.me/Upgrade-PHP-7.3). 

This pull request fixes problem when doing a file search on PHP7.3

This fixes https://github.com/klaussilveira/gitlist/issues/834