### PR TITLE
Only select normal files in Repository.getReadme

### DIFF
--- a/src/Util/Repository.php
+++ b/src/Util/Repository.php
@@ -178,7 +178,7 @@ class Repository
         $files = $repository->getTree($path != '' ? "$branch:\"$path\"" : $branch)->output();
 
         foreach ($files as $file) {
-            if (preg_match('/^readme*/i', $file['name'])) {
+            if ($file['type'] == 'blob' && preg_match('/^readme*/i', $file['name'])) {
                 return array(
                     'filename' => $file['name'],
                     'content' => $repository->getBlob("$branch:\"$path{$file['name']}\"")->output(),


### PR DESCRIPTION
Some projects have both a directory `README` (containing images and the like) and a `README.md`. If the `README` directory were to be selected this gives a weird string representation.