### PR TITLE
Dynamic package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+on:
+  push:
+    tags:
+    - '*'
+
+name: Release Gitlist
+
+jobs:
+  build:
+    name: Build and upload Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: nanasess/setup-php@v3.0.4
+        with:
+          php-version: '7.1'
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build project
+        id: build
+        run: |
+                echo ::set-output name=TAG_NAME::$(echo ${GITHUB_REF##refs\/tags\/})
+                ant build
+                ant build-package
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
+          asset_path: build/gitlist-${{ steps.build.outputs.TAG_NAME }}.tar.gz
+          asset_name: gitlist-${{ steps.build.outputs.TAG_NAME }}.tar.gz
+          asset_content_type: application/tar+gzip
+
+  gh-pages:
+    name: Update GitHub pages
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: 'gh-pages'
+      - name: Update index.html
+        id: index_html
+        env:
+          TAG_NAME: ${{ github.ref }}
+        run: |
+          sed -i "
+          /<!-- The following line is updated automatically by a Github action./ { N; /\/releases\/download\// D }
+          /\/releases\/download\// c\
+          \                        <!-- The following line is updated automatically by a Github action. To modify, update '${GITHUB_WORKFLOW}' workflow instead. -->\n\
+          \                        <a class=\"btn btn-large btn-primary\" href=\"https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG_NAME##refs/tags/}/gitlist-${TAG_NAME##refs/tags/}.tar.gz\"><b>Latest stable(${TAG_NAME##refs/tags/})</b></a>" index.html
+          echo ::set-output name=TAG_NAME::$(echo ${GITHUB_REF##refs\/tags\/})
+      - name: Commit GitHub pages
+        uses: EndBug/add-and-commit@v4.2.0
+        with:
+           add: 'index.html'
+           ref: 'gh-pages'
+           message: 'Auto update download link to ${{ steps.index_html.outputs.TAG_NAME }}'
+        env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this line unchanged

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ nbproject
 .idea
 node_modules
 config.ini
+release.ini
 cache.properties
 composer.phar
 phpunit.xml

--- a/build.xml
+++ b/build.xml
@@ -15,6 +15,16 @@
         </exec>
     </target>
 
+    <exec executable="/bin/bash" outputproperty="gitTag" >
+        <arg value="-c" />
+        <arg value="git describe --tags --exact-match || git describe --all --abbrev --exact-match || git describe --tags" />
+        <redirector outputproperty="gitTag" error="/dev/null">
+            <outputfilterchain>
+                <replacestring from="heads/" to="" />
+            </outputfilterchain>
+        </redirector>
+    </exec>
+
     <target name="prepare" depends="clean,get-composer" description="Prepare for build">
         <mkdir dir="${basedir}/build/logs"/>
         <mkdir dir="${basedir}/build/pdepend"/>
@@ -55,11 +65,11 @@
             <fileset dir="${basedir}" excludes="cache/**, build/**, tests/**, pkg_builder/**, phpunit.xml.dist, cache.properties, .gitignore, .travis.yml, build.xml, composer.json, composer.lock, composer.phar, config.ini" />
         </copy>
 
-        <tar destfile="${basedir}/build/gitlist-master.tar.gz"
+        <tar destfile="${basedir}/build/gitlist-${gitTag}.tar.gz"
             basedir="${basedir}/build/"
             compression="gzip"
             longfile="gnu"
-            excludes="gitlist-master.tar.gz, **/phpunit.xml.dist, **/composer.lock, **/composer.json, **/.travis.yml, **/test/**, **/tests/**, **/logs/**, **/pdepend/**"
+            excludes="gitlist-${gitTag}.tar.gz, **/phpunit.xml.dist, **/composer.lock, **/composer.json, **/.travis.yml, **/test/**, **/tests/**, **/logs/**, **/pdepend/**"
         />
     </target>
 </project>

--- a/build.xml
+++ b/build.xml
@@ -24,6 +24,9 @@
             </outputfilterchain>
         </redirector>
     </exec>
+    <propertyfile file="${basedir}/release.ini">
+        <entry  key="release_name" value="${gitTag}"/>
+    </propertyfile>
 
     <target name="prepare" depends="clean,get-composer" description="Prepare for build">
         <mkdir dir="${basedir}/build/logs"/>

--- a/index.php
+++ b/index.php
@@ -20,6 +20,7 @@ if (!is_writable(__DIR__ . DIRECTORY_SEPARATOR . 'cache')) {
 require 'vendor/autoload.php';
 
 $config = GitList\Config::fromFile('config.ini');
+$config->setSection('release', parse_ini_file('release.ini', true));
 
 if ($config->get('date', 'timezone')) {
     date_default_timezone_set($config->get('date', 'timezone'));

--- a/src/Application.php
+++ b/src/Application.php
@@ -17,7 +17,6 @@ use Symfony\Component\Filesystem\Filesystem;
 class Application extends SilexApplication
 {
     protected $path;
-    protected $release;
 
     /**
      * Constructor initialize services.
@@ -67,8 +66,6 @@ class Application extends SilexApplication
         $this->register(new RoutingUtilServiceProvider());
         $this->register(new UrlGeneratorServiceProvider());
 
-	$this->release=parse_ini_file('release.ini', true);
-
         $this['twig'] = $this->share($this->extend('twig', function ($twig, $app) use ($config) {
             $twig->addFilter(new \Twig_SimpleFilter('htmlentities', 'htmlentities'));
             $twig->addFilter(new \Twig_SimpleFilter('md5', 'md5'));
@@ -87,7 +84,7 @@ class Application extends SilexApplication
             $twig->addGlobal('ssh_url_subdir', $config->get('clone_button', 'ssh_url_subdir'));
             $twig->addGlobal('ssh_host', $config->get('clone_button', 'ssh_host'));
             $twig->addGlobal('ssh_port', $config->get('clone_button', 'ssh_port'));
-            $twig->addGlobal('release_name', $this->release['release_name']);
+            $twig->addGlobal('release_name', $config->get('release', 'release_name'));
 
 
             return $twig;

--- a/src/Application.php
+++ b/src/Application.php
@@ -17,6 +17,7 @@ use Symfony\Component\Filesystem\Filesystem;
 class Application extends SilexApplication
 {
     protected $path;
+    protected $release;
 
     /**
      * Constructor initialize services.
@@ -66,6 +67,8 @@ class Application extends SilexApplication
         $this->register(new RoutingUtilServiceProvider());
         $this->register(new UrlGeneratorServiceProvider());
 
+	$this->release=parse_ini_file('release.ini', true);
+
         $this['twig'] = $this->share($this->extend('twig', function ($twig, $app) use ($config) {
             $twig->addFilter(new \Twig_SimpleFilter('htmlentities', 'htmlentities'));
             $twig->addFilter(new \Twig_SimpleFilter('md5', 'md5'));
@@ -84,6 +87,8 @@ class Application extends SilexApplication
             $twig->addGlobal('ssh_url_subdir', $config->get('clone_button', 'ssh_url_subdir'));
             $twig->addGlobal('ssh_host', $config->get('clone_button', 'ssh_host'));
             $twig->addGlobal('ssh_port', $config->get('clone_button', 'ssh_port'));
+            $twig->addGlobal('release_name', $this->release['release_name']);
+
 
             return $twig;
         }));

--- a/src/Config.php
+++ b/src/Config.php
@@ -51,6 +51,11 @@ class Config
         $this->data[$section][$option] = $value;
     }
 
+    public function setSection($section, $value)
+    {
+        $this->data[$section] = $value;
+    }
+
     protected function validateOptions()
     {
         $repositories = $this->get('git', 'repositories');

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -147,6 +147,7 @@ class InterfaceTest extends WebTestCase
         $config->set('git', 'client', self::$gitPath);
         $config->set('git', 'default_branch', 'master');
         $config->set('git', 'repositories', array(self::$tmpdir));
+        $config->set('release', 'release_name', 'test');
 
         $app = require 'boot.php';
 

--- a/themes/default/twig/footer.twig
+++ b/themes/default/twig/footer.twig
@@ -1,3 +1,3 @@
 <footer>
-    <p>Powered by <a href="https://github.com/klaussilveira/gitlist">GitList 1.0.2</a></p>
+    <p>Powered by <a href="https://github.com/klaussilveira/gitlist">GitList {{ release_name }}</a></p>
 </footer>


### PR DESCRIPTION
Hi,

I am proposing this implementation to :
- Implement enhancement mentioned in issue #570 (also useful for testing => branch/tag always clearly visible in footer)
- Ease package generation with proper tar name (typically using build-package target)

I discovered about ant's build.xml and twig this week, so any critics welcome !

Cheers,
Hoel