### PR TITLE
add a ksort, so that repository index is ordered

### DIFF
--- a/src/App/Controller/Repository.php
+++ b/src/App/Controller/Repository.php
@@ -21,6 +21,8 @@ class Repository
     {
         $repositories = $this->index->getRepositories();
 
+        ksort($repositories);
+
         return new Response($this->templating->render('Repository/list.html.twig', [
             'repositories' => $repositories,
         ]));


### PR DESCRIPTION
I have a bunch of small repos, and with v2.0.0 there is currently no sorting on the index page, and is very chaotic.

Adding a quick ksort, to get at least some ordering.

