### PR TITLE
Allow horizontal scrolling in diff cards

### DIFF
--- a/assets/themes/default/assets/scss/card.scss
+++ b/assets/themes/default/assets/scss/card.scss
@@ -9,6 +9,7 @@
   padding: 0;
   margin: 0;
   overflow: clip;
+  overflow-x: scroll;
 }
 
 .card-body {


### PR DESCRIPTION
Hello,

The diff view can be frustrating to use when files have long lines. The info I am searching seems to always be 3 characters to the right of what is being displayed.

Horizontal scrolling seems a reasonable fix for 80-col-heathens like me.

Tested on Firefox and Edge : both work fine and look nice.