### PR TITLE
Add PHP dependencies to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ GitList is an elegant and modern web interface for interacting with multiple git
 In order to run GitList on your server, you'll need:
 
 * PHP 8.1
+  * php-xml
+  * php-mbstring
 * git 2
 * Webserver (Apache, nginx)
 


### PR DESCRIPTION
When installing gitlist on my server I had a number of annoying-to-debug errors which turned out to be due to missing PHP modules.

I'm not sure if these are packaged the same way on every distro (my server runs Debian) but I made a note of them in the README. They could also be in troubleshooting steps?